### PR TITLE
Feature/eye 41

### DIFF
--- a/app/src/main/java/ac/sbmax002/eye_on/camera/CameraManager.kt
+++ b/app/src/main/java/ac/sbmax002/eye_on/camera/CameraManager.kt
@@ -48,6 +48,7 @@ class CameraManager(
         // ImageAnalysis UseCase
         imageAnalysis = ImageAnalysis.Builder() // 카메라 프레임을 받아서 분석하는 usecae builder
             .setTargetResolution(targetSize) //분석용 프레임 해상도 지정
+            .setOutputImageFormat(ImageAnalysis.OUTPUT_IMAGE_FORMAT_RGBA_8888) // 모델이 RGBA_8888로 포멧을 사용
             .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)//프레임이 많이 들어 왔을 떄 오래된 프레임은 버림
             .build()
             .also {

--- a/app/src/main/java/ac/sbmax002/eye_on/model/pipeline/DrowsinessDetector.kt
+++ b/app/src/main/java/ac/sbmax002/eye_on/model/pipeline/DrowsinessDetector.kt
@@ -1,28 +1,61 @@
 package ac.sbmax002.eye_on.model.pipeline
 
-/**
- * 프레임마다 EAR 값을 받아서
- * 일정 프레임 이상 "눈 감김" 상태가 지속되면 졸음으로 판단하는 클래스.
- */
 class DrowsinessDetector(
-    private val earThreshold: Float = 0.25f,          // 이 값보다 EAR가 작으면 눈 감김으로 판단
-    private val consecutiveFrameThreshold: Int = 15   // 몇 프레임 연속이면 졸음으로 볼지
+    private val earThreshold: Float = 0.25f,   // EAR 이 이 값보다 작으면 "감겼다"
+    private val drowsyFrameThreshold: Int = 15,   // 이만큼 연속으로 감기면 "졸음"
+    private val sleepingFrameThreshold: Int = 45, // 이만큼 연속으로 감기면 "잔다"
+    private val recoverFrameThreshold: Int = 10   // 다시 눈 뜬 상태가 이만큼 유지되면 NORMAL 복귀
 ) {
 
-    private var closedFrameCount: Int = 0
+    private var closedFrameCount: Int = 0   // 연속으로 눈을 감은 프레임 수
+    private var openFrameCount: Int = 0     // 연속으로 눈을 뜬 프레임 수
+    private var state: DrowsinessState = DrowsinessState.NORMAL
 
     /**
-     * @return true 이면 이번 프레임에서 '졸음 상태'라고 판정
+     * 한 프레임의 EAR(left/right) 를 받아서
+     * 내부 상태를 업데이트하고 현재 졸음 상태를 리턴한다.
      */
-    fun update(leftEar: Float?, rightEar: Float?): Boolean {
-        // TODO: 나중에 EAR 기반 졸음 로직 구현
-        //  - EAR 둘 다 threshold 아래면 closedFrameCount++
-        //  - 아니면 closedFrameCount = 0
-        //  - closedFrameCount >= consecutiveFrameThreshold 이면 true
-        return false
+    fun update(leftEar: Float?, rightEar: Float?): DrowsinessState {
+        val leftClosed = isEyeClosed(leftEar)
+        val rightClosed = isEyeClosed(rightEar)
+        // 둘 다 감겨 있을 때만 "닫힘"으로 본다 (필요하면 한쪽만으로도 감지하도록 바꿀 수 있음)
+        val bothClosed = leftClosed && rightClosed
+
+        if (bothClosed) {
+            closedFrameCount += 1
+            openFrameCount = 0
+        } else {
+            closedFrameCount = 0
+            openFrameCount += 1
+        }
+
+        // 닫힌 프레임 수에 따라 상태 진입
+        state = when {
+            bothClosed && closedFrameCount >= sleepingFrameThreshold ->
+                DrowsinessState.SLEEPING
+            bothClosed && closedFrameCount >= drowsyFrameThreshold ->
+                DrowsinessState.DROWSY
+            else -> state   // 나머지는 상태 유지
+        }
+
+        // 다시 눈 뜬 상태가 일정 프레임 이상 유지되면 NORMAL 로 복귀
+        if (!bothClosed && openFrameCount >= recoverFrameThreshold) {
+            state = DrowsinessState.NORMAL
+            closedFrameCount = 0
+        }
+
+        return state
     }
 
     fun reset() {
         closedFrameCount = 0
+        openFrameCount = 0
+        state = DrowsinessState.NORMAL
     }
+
+    // EAR 값으로 한 프레임에서 "눈 감김" 여부만 판단
+    fun isEyeClosed(ear: Float?): Boolean =
+        ear != null && ear < earThreshold
+
+    fun currentState(): DrowsinessState = state
 }

--- a/app/src/main/java/ac/sbmax002/eye_on/model/pipeline/DrowsinessDetector.kt
+++ b/app/src/main/java/ac/sbmax002/eye_on/model/pipeline/DrowsinessDetector.kt
@@ -1,61 +1,107 @@
 package ac.sbmax002.eye_on.model.pipeline
 
+/**
+ * EAR 기반 졸음 상태 감지기
+ *
+ * - 사람마다 눈 크기가 달라서 EAR 절대값이 다르기 때문에
+ *   "기본 EAR(눈 뜨고 있을 때 평균)"을 세션 동안 학습해서
+ *   그 값의 일정 비율 아래로 떨어지면 눈 감김으로 본다.
+ */
 class DrowsinessDetector(
-    private val earThreshold: Float = 0.25f,   // EAR 이 이 값보다 작으면 "감겼다"
-    private val drowsyFrameThreshold: Int = 15,   // 이만큼 연속으로 감기면 "졸음"
-    private val sleepingFrameThreshold: Int = 45, // 이만큼 연속으로 감기면 "잔다"
-    private val recoverFrameThreshold: Int = 10   // 다시 눈 뜬 상태가 이만큼 유지되면 NORMAL 복귀
+    private val baseEarThreshold: Float = 0.25f,    // 초기 몇 프레임 동안 쓸 기본 임계값 (baseline 없을 때만 사용)
+    private val closedRatio: Float = 0.7f,          // baselineEAR * closedRatio 보다 작으면 감김으로 판단
+    private val drowsyFrameThreshold: Int = 15,     // 연속 N프레임 감기면 "졸음"
+    private val sleepingFrameThreshold: Int = 60,   // 연속 N프레임 감기면 "잔다"
+    private val recoverFrameThreshold: Int = 15,    // 연속 N프레임 뜨면 "평상시" 복귀
+    private val baselineSmoothing: Float = 0.01f    // baselineEAR를 업데이트하는 가중치 (0~1, 작을수록 천천히 변화)
 ) {
 
-    private var closedFrameCount: Int = 0   // 연속으로 눈을 감은 프레임 수
-    private var openFrameCount: Int = 0     // 연속으로 눈을 뜬 프레임 수
+    // 세션 동안의 "눈 뜬 상태" EAR 평균(적응형)
+    private var baselineEar: Float = 0f
+
+    private var closedFrameCount: Int = 0
+    private var openFrameCount: Int = 0
     private var state: DrowsinessState = DrowsinessState.NORMAL
 
     /**
-     * 한 프레임의 EAR(left/right) 를 받아서
-     * 내부 상태를 업데이트하고 현재 졸음 상태를 리턴한다.
+     * 매 프레임마다 왼/오른쪽 EAR 값을 받아서
+     * - baseline EAR 업데이트
+     * - 졸음 상태(NORMAL/DROWSY/SLEEPING) 업데이트
+     * 를 수행하고 현재 상태를 반환한다.
      */
     fun update(leftEar: Float?, rightEar: Float?): DrowsinessState {
-        val leftClosed = isEyeClosed(leftEar)
-        val rightClosed = isEyeClosed(rightEar)
-        // 둘 다 감겨 있을 때만 "닫힘"으로 본다 (필요하면 한쪽만으로도 감지하도록 바꿀 수 있음)
-        val bothClosed = leftClosed && rightClosed
+        // 1) 현재 EAR 평균 (존재하는 값만 평균)
+        val ears = listOfNotNull(leftEar, rightEar)
+        val avgEar: Float? = if (ears.isNotEmpty()) {
+            ears.average().toFloat()
+        } else {
+            null
+        }
 
-        if (bothClosed) {
-            closedFrameCount += 1
+        // 2) 이전 baseline 기준으로 "감김/뜸" 판단
+        val leftClosedNow = isEyeClosed(leftEar)
+        val rightClosedNow = isEyeClosed(rightEar)
+        val bothClosedNow = leftClosedNow && rightClosedNow
+
+        // 3) 눈을 뜨고 있을 때만 baselineEAR 를 조금씩 업데이트
+        if (!bothClosedNow && avgEar != null && avgEar > 0f) {
+            baselineEar = if (baselineEar == 0f) {
+                avgEar                    // 초기값 세팅
+            } else {
+                // 지수 이동 평균 형태로 천천히 따라가게 함
+                baselineEar * (1f - baselineSmoothing) + avgEar * baselineSmoothing
+            }
+        }
+
+        // 4) 연속 프레임 카운트 갱신
+        if (bothClosedNow) {
+            closedFrameCount++
             openFrameCount = 0
         } else {
+            openFrameCount++
             closedFrameCount = 0
-            openFrameCount += 1
         }
 
-        // 닫힌 프레임 수에 따라 상태 진입
+        // 5) 감긴 프레임 수에 따라 졸음/수면 상태 진입
         state = when {
-            bothClosed && closedFrameCount >= sleepingFrameThreshold ->
+            bothClosedNow && closedFrameCount >= sleepingFrameThreshold ->
                 DrowsinessState.SLEEPING
-            bothClosed && closedFrameCount >= drowsyFrameThreshold ->
+            bothClosedNow && closedFrameCount >= drowsyFrameThreshold ->
                 DrowsinessState.DROWSY
-            else -> state   // 나머지는 상태 유지
+            else -> state   // 그 외에는 이전 상태 유지
         }
 
-        // 다시 눈 뜬 상태가 일정 프레임 이상 유지되면 NORMAL 로 복귀
-        if (!bothClosed && openFrameCount >= recoverFrameThreshold) {
+        // 6) 눈 뜬 상태가 일정 프레임 이상 유지되면 무조건 NORMAL 복귀
+        if (!bothClosedNow && openFrameCount >= recoverFrameThreshold) {
             state = DrowsinessState.NORMAL
-            closedFrameCount = 0
         }
 
         return state
     }
 
+    /**
+     * 현재 기준으로 한 프레임에서 "눈 감김" 여부를 판정
+     */
+    fun isEyeClosed(ear: Float?): Boolean {
+        if (ear == null || ear <= 0f) return false
+
+        // baseline 이 충분히 쌓였으면 그걸 기준으로,
+        // 아니면 초기 baseEarThreshold를 사용
+        val effectiveThreshold: Float = if (baselineEar > 0f) {
+            baselineEar * closedRatio
+        } else {
+            baseEarThreshold
+        }
+
+        return ear < effectiveThreshold
+    }
+
+    fun currentState(): DrowsinessState = state
+
     fun reset() {
+        baselineEar = 0f
         closedFrameCount = 0
         openFrameCount = 0
         state = DrowsinessState.NORMAL
     }
-
-    // EAR 값으로 한 프레임에서 "눈 감김" 여부만 판단
-    fun isEyeClosed(ear: Float?): Boolean =
-        ear != null && ear < earThreshold
-
-    fun currentState(): DrowsinessState = state
 }

--- a/app/src/main/java/ac/sbmax002/eye_on/model/pipeline/EarCalulator.kt
+++ b/app/src/main/java/ac/sbmax002/eye_on/model/pipeline/EarCalulator.kt
@@ -1,17 +1,38 @@
 package ac.sbmax002.eye_on.model.pipeline
 
+import com.google.mediapipe.tasks.components.containers.NormalizedLandmark
+import kotlin.math.hypot
+
 /**
  * 눈 랜드마크 좌표들에서 EAR 값을 계산하는 클래스.
  */
 class EarCalculator {
 
     /**
-     * @param eyePoints 눈 주변 랜드마크 좌표들
-     *        (나중에 인덱스/순서 정의해서 전달)
-     * @return EAR 값
+     * eyePoints 리스트는 p1~p6 순서로 들어온다고 가정한다.
+     * EAR = (||p2 - p6|| + ||p3 - p5||) / (2 * ||p1 - p4||)
      */
-    fun calculateEar(eyePoints: List<Pair<Float, Float>>): Float {
-        // TODO: 나중에 EAR 공식으로 실제 계산 로직 채우기
-        return 0f
+    fun calculateEar(eyePoints: List<NormalizedLandmark>): Float {
+        if (eyePoints.size < 6) return 0f
+
+        fun dist(a: NormalizedLandmark, b: NormalizedLandmark): Float {
+            val dx = a.x() - b.x()
+            val dy = a.y() - b.y()
+            return hypot(dx.toDouble(), dy.toDouble()).toFloat()
+        }
+
+        val p1 = eyePoints[0]
+        val p2 = eyePoints[1]
+        val p3 = eyePoints[2]
+        val p4 = eyePoints[3]
+        val p5 = eyePoints[4]
+        val p6 = eyePoints[5]
+
+        val A = dist(p2, p6)
+        val B = dist(p3, p5)
+        val C = dist(p1, p4)
+
+        if (C == 0f) return 0f
+        return (A + B) / (2f * C)
     }
 }

--- a/app/src/main/java/ac/sbmax002/eye_on/model/pipeline/EarCalulator.kt
+++ b/app/src/main/java/ac/sbmax002/eye_on/model/pipeline/EarCalulator.kt
@@ -9,7 +9,7 @@ import kotlin.math.hypot
 class EarCalculator {
 
     /**
-     * eyePoints 리스트는 p1~p6 순서로 들어온다고 가정한다.
+     * eyePoints 리스트는 p1~p6 순서로 들어옴
      * EAR = (||p2 - p6|| + ||p3 - p5||) / (2 * ||p1 - p4||)
      */
     fun calculateEar(eyePoints: List<NormalizedLandmark>): Float {

--- a/app/src/main/java/ac/sbmax002/eye_on/model/pipeline/FaceProcessingPipeline.kt
+++ b/app/src/main/java/ac/sbmax002/eye_on/model/pipeline/FaceProcessingPipeline.kt
@@ -2,6 +2,7 @@ package ac.sbmax002.eye_on.model.pipeline
 
 import ac.sbmax002.eye_on.model.vision.FaceLandmarkerHelper
 import android.content.Context
+import android.util.Log
 import androidx.camera.core.ImageProxy
 import com.google.mediapipe.tasks.components.containers.NormalizedLandmark
 
@@ -36,10 +37,16 @@ class FaceProcessingPipeline(
                 imageProxy.close()
             } catch (_: Exception) { /* ignore */ }
 
+            //테스트 로그
+            Log.e("FacePipeline", "process error: ${e.message}", e)
             listener.onPipelineError(
                 "FaceProcessing failed: ${e.message ?: "unknown error"}"
             )
         }
+    }
+
+    fun reset() {
+        drowsinessDetector.reset()
     }
 
     override fun onError(error: String, errorCode: Int) {
@@ -51,6 +58,14 @@ class FaceProcessingPipeline(
 
     override fun onResults(resultBundle: FaceLandmarkerHelper.ResultBundle) {
         val faceResult = resultBundle.result
+
+        // 지연시간 로그 출력
+        Log.d(
+            "FacePipeline",
+            "inferenceTime=${resultBundle.inferenceTime}ms, " +
+                    "timestamp=${faceResult.timestampMs()}, " +
+                    "faces=${faceResult.faceLandmarks().size}"
+        )
 
         // 1. 얼굴이 하나도 없으면 바로 결과 내려주고 끝
         if (faceResult.faceLandmarks().isEmpty()) {
@@ -65,7 +80,7 @@ class FaceProcessingPipeline(
             return
         }
 
-        // 지금은 maxNumFaces = 1 기준으로 0번만 사용
+        //  maxNumFaces = 1  기준으로 0번만 사용
         val landmarks = faceResult.faceLandmarks()[0]
 
         // 2. ROI 추출

--- a/app/src/main/java/ac/sbmax002/eye_on/model/pipeline/FaceProcessingPipeline.kt
+++ b/app/src/main/java/ac/sbmax002/eye_on/model/pipeline/FaceProcessingPipeline.kt
@@ -2,15 +2,12 @@ package ac.sbmax002.eye_on.model.pipeline
 
 import ac.sbmax002.eye_on.model.vision.FaceLandmarkerHelper
 import android.content.Context
-import android.util.Log
 import androidx.camera.core.ImageProxy
+import com.google.mediapipe.tasks.components.containers.NormalizedLandmark
 
 /**
- * CameraX 프레임 -> MediaPipe FaceLandmarker -> ROI -> EAR -> 졸음 여부
- * 를 조율하는 파이프라인 클래스의 뼈대.
- *
- * 실제 로직은 다음 단계에서 채우고,
- * 지금은 구조/타입만 맞춰둔다.
+ * CameraX 프레임 -> MediaPipe FaceLandmarker -> ROI -> EAR -> 졸음 상태
+ * 전체 파이프라인을 조율하는 클래스.
  */
 class FaceProcessingPipeline(
     context: Context,
@@ -20,56 +17,100 @@ class FaceProcessingPipeline(
     private val drowsinessDetector: DrowsinessDetector = DrowsinessDetector()
 ) : FaceLandmarkerHelper.LandmarkerListener {
 
-    // MediaPipe 헬퍼는 파이프라인이 직접 소유
+    // MediaPipe 얼굴 랜드마커 헬퍼
     private val faceLandmarkerHelper = FaceLandmarkerHelper(
         context = context,
         faceLandmarkerHelperListener = this
     )
 
     /**
-     * CameraX Analyzer에서 호출할 진입 메소드.
-     * 지금은 메모리 누수만 막고, 추론은 다음 단계에서 연결할 거라
-     * 프레임을 바로 닫기만 한다.
+     * CameraX ImageAnalysis.Analyzer 쪽에서 매 프레임마다 호출해 줄 진입점.
      */
     fun process(imageProxy: ImageProxy, isFrontCamera: Boolean) {
-        // TODO: 실제 모델 연결
-        //테스트로그
-        Log.d("FaceProcessingPipeline", "frame arrived: ${imageProxy.imageInfo.timestamp}")
-        // faceLandmarkerHelper.detectLiveStream(imageProxy, isFrontCamera)
-        // 로 바꾸고, 여기서 close()는 제거할 예정.
+        try {
+            // 비동기 라이브스트림 추론 시작 (내부에서 imageProxy.close()까지 처리)
+            faceLandmarkerHelper.detectLiveStream(imageProxy, isFrontCamera)
+        } catch (e: Exception) {
+            // 예외 시에는 직접 닫아주고, 상위로 에러 전달
+            try {
+                imageProxy.close()
+            } catch (_: Exception) { /* ignore */ }
 
-        imageProxy.close()
-    }
-
-    // ---------------------------------------------------------------------
-    // FaceLandmarkerHelper.LandmarkerListener 구현부
-    // ---------------------------------------------------------------------
-
-    override fun onResults(resultBundle: FaceLandmarkerHelper.ResultBundle) {
-        // TODO:
-        //  1) resultBundle.result 로부터 얼굴 랜드마크 리스트 꺼내기
-        //  2) RoiExtractor로 왼/오른쪽 눈 좌표 추출
-        //  3) EarCalculator로 EAR 계산
-        //  4) DrowsinessDetector로 졸음 여부 판단
-        //  5) PipelineResult 만들어 listener로 전달
-
-        // 일단 구조만 보이도록 더미 결과 한 번 만들어놓음.
-        val dummyResult = PipelineResult(
-            frameTimestampMs = System.currentTimeMillis(),
-            isFaceDetected = true,
-            leftEye = null,
-            rightEye = null,
-            isDrowsy = false
-        )
-        listener.onPipelineResult(dummyResult)
+            listener.onPipelineError(
+                "FaceProcessing failed: ${e.message ?: "unknown error"}"
+            )
+        }
     }
 
     override fun onError(error: String, errorCode: Int) {
         listener.onPipelineError(error)
     }
+    // ---------------------------------------------------------------------
+    // FaceLandmarkerHelper.LandmarkerListener 구현부
+    // ---------------------------------------------------------------------
+
+    override fun onResults(resultBundle: FaceLandmarkerHelper.ResultBundle) {
+        val faceResult = resultBundle.result
+
+        // 1. 얼굴이 하나도 없으면 바로 결과 내려주고 끝
+        if (faceResult.faceLandmarks().isEmpty()) {
+            val empty = PipelineResult(
+                frameTimestampMs = faceResult.timestampMs(),
+                isFaceDetected = false,
+                leftEye = null,
+                rightEye = null,
+                drowsinessState = DrowsinessState.NORMAL
+            )
+            listener.onPipelineResult(empty)
+            return
+        }
+
+        // 지금은 maxNumFaces = 1 기준으로 0번만 사용
+        val landmarks = faceResult.faceLandmarks()[0]
+
+        // 2. ROI 추출
+        val eyeRoi = roiExtractor.extractEyeRoi(landmarks)
+
+        // 3. EAR 계산 (좌표가 아직 비어 있다면 null 반환)
+        val leftEar = eyeRoi.leftEyePoints.takeIf { it.isNotEmpty() }
+            ?.let { earCalculator.calculateEar(it) }
+        val rightEar = eyeRoi.rightEyePoints.takeIf { it.isNotEmpty() }
+            ?.let { earCalculator.calculateEar(it) }
+
+        // 4. 졸음 상태 업데이트 (3단계)
+        val drowsinessState = drowsinessDetector.update(leftEar, rightEar)
+
+        // 5. ViewModel에 넘겨줄 DTO 만들기
+        val result = PipelineResult(
+            frameTimestampMs = faceResult.timestampMs(),
+            isFaceDetected = true,
+            leftEye = leftEar?.let { ear ->
+                EyeState(
+                    ear = ear,
+                    isClosed = drowsinessDetector.isEyeClosed(ear)
+                )
+            },
+            rightEye = rightEar?.let { ear ->
+                EyeState(
+                    ear = ear,
+                    isClosed = drowsinessDetector.isEyeClosed(ear)
+                )
+            },
+            drowsinessState = drowsinessState
+        )
+
+        listener.onPipelineResult(result)
+    }
 
     override fun onEmpty() {
-        // 얼굴이 하나도 안 잡힌 프레임 처리하고 싶으면
-        // 나중에 여기에서 listener.onPipelineResult(...) 호출 추가
+        // 얼굴이 전혀 없는 프레임도 필요하면 이렇게 내려줄 수 있음
+        val result = PipelineResult(
+            frameTimestampMs = System.currentTimeMillis(),
+            isFaceDetected = false,
+            leftEye = null,
+            rightEye = null,
+            drowsinessState = drowsinessDetector.currentState()
+        )
+        listener.onPipelineResult(result)
     }
 }

--- a/app/src/main/java/ac/sbmax002/eye_on/model/pipeline/PipeLineResult.kt
+++ b/app/src/main/java/ac/sbmax002/eye_on/model/pipeline/PipeLineResult.kt
@@ -3,25 +3,33 @@ package ac.sbmax002.eye_on.model.pipeline
 /**
  * 한 쪽 눈 상태
  */
+// 한쪽 눈의 상태
 data class EyeState(
-    val ear: Float,      // 계산된 EAR 값
-    val isClosed: Boolean // EAR 기준으로 눈이 감긴 상태인지
+    val ear: Float,      // 이 프레임의 EAR 값
+    val isClosed: Boolean  // 이 프레임에서 "감겼다" 여부 (threshold 기반)
 )
 
-/**
- * 비전 파이프라인 전체 결과
- */
+// 졸음 상태 3단계
+enum class DrowsinessState {
+    NORMAL,   // 평상시
+    DROWSY,   // 졸음
+    SLEEPING  // 잔다 (오래 감고 있음)
+}
+
+// 전체 파이프라인 결과
 data class PipelineResult(
     val frameTimestampMs: Long,
     val isFaceDetected: Boolean,
     val leftEye: EyeState?,
     val rightEye: EyeState?,
+    val drowsinessState: DrowsinessState
+) {
+    // 필요하면 이전처럼 Boolean 으로도 쓸 수 있게
     val isDrowsy: Boolean
-)
+        get() = drowsinessState != DrowsinessState.NORMAL
+}
 
-/**
- * 파이프라인 결과를 ViewModel/UI 쪽으로 보내기 위한 콜백 인터페이스
- */
+// ViewModel 쪽으로 결과를 전달하기 위한 리스너
 interface PipelineListener {
     fun onPipelineResult(result: PipelineResult)
     fun onPipelineError(message: String)

--- a/app/src/main/java/ac/sbmax002/eye_on/model/pipeline/RoiExtractor.kt
+++ b/app/src/main/java/ac/sbmax002/eye_on/model/pipeline/RoiExtractor.kt
@@ -16,14 +16,23 @@ data class EyeRoi(
  * 눈 주변 좌표만 뽑아주는 역할.
  */
 class RoiExtractor {
+    // p1~p6 순서로 사용됨 (EAR 수식과 매핑)
+    private val leftEyeIndices = listOf(362, 385, 387, 263, 373, 380)
+    private val rightEyeIndices = listOf(33, 160, 158, 133, 153, 144)
 
-    /**
-     * @param result FaceLandmarkerResult
-     * @return 눈 주변 랜드마크 좌표들(정규화 또는 픽셀 좌표)
-     */
     fun extractEyeRoi(landmarks: List<NormalizedLandmark>): EyeRoi {
-        // TODO: 나중에 얼굴 랜드마크 인덱스를 이용해서
-        //       왼/오른쪽 눈 좌표만 추출하는 로직 구현
-        return EyeRoi()
+        // 혹시라도 랜드마크 개수가 부족하면 빈 ROI 리턴
+        val maxIndex = (leftEyeIndices + rightEyeIndices).maxOrNull() ?: 0
+        if (landmarks.size <= maxIndex) {
+            return EyeRoi()
+        }
+
+        val left = leftEyeIndices.map { idx -> landmarks[idx] }
+        val right = rightEyeIndices.map { idx -> landmarks[idx] }
+
+        return EyeRoi(
+            leftEyePoints = left,
+            rightEyePoints = right
+        )
     }
 }

--- a/app/src/main/java/ac/sbmax002/eye_on/model/pipeline/RoiExtractor.kt
+++ b/app/src/main/java/ac/sbmax002/eye_on/model/pipeline/RoiExtractor.kt
@@ -1,13 +1,14 @@
 package ac.sbmax002.eye_on.model.pipeline
 
+import com.google.mediapipe.tasks.components.containers.NormalizedLandmark
 import com.google.mediapipe.tasks.vision.facelandmarker.FaceLandmarkerResult
 
 /**
  * 왼/오른쪽 눈 영역(랜드마크들)을 묶어서 들고 있을 데이터 클래스
  */
 data class EyeRoi(
-    val leftEyePoints: List<Pair<Float, Float>> = emptyList(),
-    val rightEyePoints: List<Pair<Float, Float>> = emptyList()
+    val leftEyePoints: List<NormalizedLandmark> = emptyList(),
+    val rightEyePoints: List<NormalizedLandmark> = emptyList()
 )
 
 /**
@@ -20,7 +21,7 @@ class RoiExtractor {
      * @param result FaceLandmarkerResult
      * @return 눈 주변 랜드마크 좌표들(정규화 또는 픽셀 좌표)
      */
-    fun extractEyeRoi(result: FaceLandmarkerResult): EyeRoi {
+    fun extractEyeRoi(landmarks: List<NormalizedLandmark>): EyeRoi {
         // TODO: 나중에 얼굴 랜드마크 인덱스를 이용해서
         //       왼/오른쪽 눈 좌표만 추출하는 로직 구현
         return EyeRoi()


### PR DESCRIPTION
### 1) 카메라
    카메라 자체는 약 30fps 정도로 프레임을 공급

### 2) 카메라 프레임 → 파이프라인흐름 
  `pipeline.process(imageProxy, isFrontCamera = true)` 호출
        
- `FaceProcessingPipeline` 내부:
    - `FaceLandmarkerHelper.detectLiveStream()` 호출
    - 결과 콜백(`onResults`)에서:
        1. 얼굴 랜드마크 추출
        2. `RoiExtractor` 로 눈 영역 랜드마크 6개씩 추출
        3. `EarCalculator` 로 EAR(Eye Aspect Ratio) 계산
        4. `DrowsinessDetector` 로
            - `NORMAL` / `DROWSY` / `SLEEPING` 3단계 상태 판정
        5. `PipelineResult` 로 묶어서 UI쪽에 에 전달
            

### 4) EAR & ROI 기반 졸음 감지

- `RoiExtractor`
    - MediaPipe Face Landmarker의 전체 랜드마크에서
        
        EAR 계산에 필요한 눈 랜드마크 인덱스(6개)를 뽑아
        
        좌/우 눈 점 리스트로 변환
        
- `EarCalculator`
    - 전형적인 EAR 수식 사용
        - EAR = (‖p2 − p6‖ + ‖p3 − p5‖) / (2‖p1 − p4‖)
- `DrowsinessDetector`
    - 상태: `NORMAL`, `DROWSY`, `SLEEPING`
    - **⭐적응형 EAR 기준** 사용:
        - 사람마다 눈 크기가 달라서 EAR 절대값이 다르기 때문에
            
            측정 세션 동안 눈 뜬 상태 EAR 평균(`baselineEar`)을 학습
            
        - 감김 판정: `EAR < baselineEar * closedRatio` (또는 초기값 기준)
    - 상태 로직:
        - 연속 감긴 프레임 수에 따라:
            - `>= drowsyFrameThreshold` → `DROWSY`
            - `>= sleepingFrameThreshold` → `SLEEPING`
        - 연속으로 눈을 뜬 프레임 수가
            
            `recoverFrameThreshold` 이상이면 `NORMAL` 로 복귀
            
    - 측정 시작 시 `pipeline.reset()` 호출로
        - baselineEAR
        - 프레임 카운트
        - 상태를 초기화

## 모델의 프레임당 추론시간 로그

inferenceTime=51ms, faces=1

inferenceTime=48ms, faces=1

inferenceTime=43ms, faces=1

inferenceTime=52ms, faces=1

inferenceTime=45ms, faces=1

inferenceTime=40ms, faces=1

inferenceTime=63ms, faces=1

inferenceTime=49ms, faces=1

inferenceTime=53ms, faces=1

inferenceTime=49ms, faces=1

inferenceTime=64ms, faces=1

inferenceTime=49ms, faces=1

inferenceTime=61ms, faces=1

inferenceTime=50ms, faces=1

inferenceTime=69ms, faces=1

30프레임기준 약 0.5초의 지연시간 발생