### PR TITLE
[FEAT] EYE 57 모델 값들 디비에 저장

### DIFF
--- a/app/src/main/java/ac/sbmax002/eye_on/MainActivity.kt
+++ b/app/src/main/java/ac/sbmax002/eye_on/MainActivity.kt
@@ -52,9 +52,18 @@ class MainActivity : ComponentActivity() {
             monitoringService = binder?.getService()
             isServiceBound = true
             Log.d(TAG, "MonitoringService connected")
+
+            //서비스에서 올라오는 PipelineResult를 HomeViewModel로 전달
+            monitoringService?.setOnPipelineResultListener { result ->
+                homeViewModel.onPipelineResult(result)
+            }
+
         }
 
         override fun onServiceDisconnected(name: ComponentName?) {
+            // 🔹 더 이상 콜백이 불리지 않도록 해제
+            monitoringService?.setOnPipelineResultListener(null)
+
             monitoringService = null
             isServiceBound = false
             Log.d(TAG, "MonitoringService disconnected")
@@ -111,6 +120,8 @@ class MainActivity : ComponentActivity() {
 
     override fun onDestroy() {
         super.onDestroy()
+        // 콜백 해제
+        monitoringService?.setOnPipelineResultListener(null)
         // Service 바인딩 해제
         if (isServiceBound) {
             unbindService(serviceConnection)

--- a/app/src/main/java/ac/sbmax002/eye_on/database/AppDatabase.kt
+++ b/app/src/main/java/ac/sbmax002/eye_on/database/AppDatabase.kt
@@ -20,19 +20,20 @@ abstract class AppDatabase : RoomDatabase() {
         @Volatile
         private var INSTANCE: AppDatabase? = null
 
-        fun getDatabase(context: Context): AppDatabase {
+        fun getInstance(context: Context): AppDatabase {
             return INSTANCE ?: synchronized(this) {
-                val instance = Room.databaseBuilder(
+                INSTANCE ?: Room.databaseBuilder(
                     context.applicationContext,
                     AppDatabase::class.java,
-                    "eye_on_database" // 폰에 저장될 실제 파일 이름
+                    "eye_on_database" // 실제 디바이스에 만들어질 DB 파일 이름
                 )
-                    // 괄호안 true로 설정시 개발 중 사용하는 기존 데이터 날리고 재생성 코드
-                    // 실제 배포시에는 삭제하거나 Migration 전략을 세워야 함
+                    // 개발 중에는 스키마 바꾸면 기존 데이터 날리고 재생성
+                    // (배포용에서는 Migration 전략 필요)
                     .fallbackToDestructiveMigration()
                     .build()
-                INSTANCE = instance
-                instance
+                    .also { INSTANCE = it }
+//                INSTANCE = instance
+//                instance
             }
         }
     }

--- a/app/src/main/java/ac/sbmax002/eye_on/database/AppDatabase.kt
+++ b/app/src/main/java/ac/sbmax002/eye_on/database/AppDatabase.kt
@@ -20,20 +20,19 @@ abstract class AppDatabase : RoomDatabase() {
         @Volatile
         private var INSTANCE: AppDatabase? = null
 
-        fun getInstance(context: Context): AppDatabase {
+        fun getDatabase(context: Context): AppDatabase {
             return INSTANCE ?: synchronized(this) {
-                INSTANCE ?: Room.databaseBuilder(
+                val instance = Room.databaseBuilder(
                     context.applicationContext,
                     AppDatabase::class.java,
-                    "eye_on_database" // 실제 디바이스에 만들어질 DB 파일 이름
+                    "eye_on_database" // 폰에 저장될 실제 파일 이름
                 )
-                    // 개발 중에는 스키마 바꾸면 기존 데이터 날리고 재생성
-                    // (배포용에서는 Migration 전략 필요)
+                    // 괄호안 true로 설정시 개발 중 사용하는 기존 데이터 날리고 재생성 코드
+                    // 실제 배포시에는 삭제하거나 Migration 전략을 세워야 함
                     .fallbackToDestructiveMigration()
                     .build()
-                    .also { INSTANCE = it }
-//                INSTANCE = instance
-//                instance
+                INSTANCE = instance
+                instance
             }
         }
     }

--- a/app/src/main/java/ac/sbmax002/eye_on/database/StatisticsDao.kt
+++ b/app/src/main/java/ac/sbmax002/eye_on/database/StatisticsDao.kt
@@ -16,6 +16,10 @@ interface StatisticsDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertSession(session: DrivingSession): Long
 
+    // 세션 여러 건 삽입(MockDataSource 초기 데이터 적재용)
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertSessions(sessions: List<DrivingSession>)
+
     // 2. 운전 세션 업데이트 (종료 시간, 알림 횟수 등 갱신)
     @Update
     suspend fun updateSession(session: DrivingSession): Int
@@ -23,6 +27,10 @@ interface StatisticsDao {
     // 3. 졸음 이벤트 저장
     @Insert
     suspend fun insertEvent(event: SessionEvent): Long
+
+    // 이벤트 여러 건 삽입 (MockDataSource 초기 데이터 적재용)
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertEvents(events: List<SessionEvent>)
 
     // 4. 통계 화면용: 모든 세션을 날짜 내림차순(최신순)으로 가져오기
     // Flow를 반환하면 DB가 변경될 때마다 화면이 자동으로 갱신됩니다.
@@ -40,4 +48,23 @@ interface StatisticsDao {
     // (선택) 특정 세션 삭제
     @Query("DELETE FROM driving_sessions WHERE id = :sessionId")
     suspend fun deleteSessionById(sessionId: String): Int
+
+    // 전체 삭제 (초기화용)
+    @Query("DELETE FROM session_events")
+    suspend fun clearAllEvents()
+
+    @Query("DELETE FROM driving_sessions")
+    suspend fun clearAllSessions()
+
+    // 세션/이벤트 통째로 갈아끼우기 (MockDataSource.generateData() 초기 적재용)
+    @Transaction
+    suspend fun replaceAllData(
+        sessions: List<DrivingSession>,
+        events: List<SessionEvent>
+    ) {
+        clearAllEvents()
+        clearAllSessions()
+        insertSessions(sessions)
+        insertEvents(events)
+    }
 }

--- a/app/src/main/java/ac/sbmax002/eye_on/model/pipeline/DrowsinessDetector.kt
+++ b/app/src/main/java/ac/sbmax002/eye_on/model/pipeline/DrowsinessDetector.kt
@@ -12,19 +12,26 @@ import ac.sbmax002.eye_on.DTO.DrowsinessState
 class DrowsinessDetector(
     private val baseEarThreshold: Float = 0.25f,    // baseline 없을 때 임시로 쓸 기본값
     private val closedRatio: Float = 0.7f,          // baselineEAR * closedRatio 보다 작으면 감김으로 판단
-    private val drowsyFrameThreshold: Int = 15,     // 연속 N프레임 감기면 "졸음"
-    private val sleepingFrameThreshold: Int = 60,   // 연속 N프레임 감기면 "잔다"
-    private val recoverFrameThreshold: Int = 15,    // 연속 N프레임 뜨면 "평상시" 복귀
-    private val baselineSmoothing: Float = 0.01f,   // baselineEAR 업데이트 속도 (0~1, 작을수록 천천히)
-    private val warmupFrameThreshold: Int = 60      // 워밍업 기간 프레임 수
+    // 시간 기준 임계값 (ms 단위)
+    private val drowsyDurationMs: Long = 1_000L,     // 연속 N ms 감기면 "졸음"
+    private val sleepingDurationMs: Long = 3_000L,   // 연속 N ms 감기면 "잔다"
+    private val recoverDurationMs: Long = 1_000L,    // 연속 N ms 뜨면 "평상시" 복귀
+
+    // baseline 학습 속도
+    private val baselineSmoothing: Float = 0.01f,    // 일반 구간에서 baseline 업데이트 속도 (0~1, 작을수록 천천히)
+    private val warmupDurationMs: Long = 2_000L,     // 워밍업 기간 (ms)
+    private val warmupBaselineSmoothing: Float = 0.1f // 워밍업 구간에서만 사용하는 더 큰 학습률
 ) {
 
     // 세션 동안의 "눈 뜬 상태" EAR 평균 (적응형)
     private var baselineEar: Float = 0f
 
-    private var closedFrameCount: Int = 0
-    private var openFrameCount: Int = 0
-    private var processedFrameCount: Int = 0
+    // 시간 누적용 상태 (ms 단위)
+    private var lastTimestampMs: Long? = null
+    private var warmupElapsedMs: Long = 0L
+
+    private var closedDurationMs: Long = 0L
+    private var openDurationMs: Long = 0L
     private var state: DrowsinessState = DrowsinessState.NORMAL
 
     /**
@@ -32,7 +39,7 @@ class DrowsinessDetector(
      * - 워밍업 구간에서는 baseline만 학습하고 항상 NORMAL 유지
      * - 워밍업 이후부터 졸음 상태(NORMAL/DROWSY/SLEEPING)를 판정
      */
-    fun update(leftEar: Float?, rightEar: Float?): DrowsinessState {
+    fun update(leftEar: Float?, rightEar: Float?, frameTimestampMs: Long): DrowsinessState {
         // 1) 현재 프레임 EAR 평균 (존재하는 값만 평균)
         val ears = listOfNotNull(leftEar, rightEar)
         val avgEar: Float? = if (ears.isNotEmpty()) {
@@ -46,53 +53,66 @@ class DrowsinessDetector(
         val rightClosedNow = isEyeClosed(rightEar)
         val bothClosedNow = leftClosedNow && rightClosedNow
 
-        // 3) 처리된 프레임 카운트 (EAR가 아예 없으면 센다고 보지 않음)
-        if (avgEar != null && avgEar > 0f) {
-            processedFrameCount++
+        // 3) 시간 경과 계산 (이전 timestamp와의 차이)
+        val prevTs = lastTimestampMs
+        val deltaMs = if (prevTs != null) {
+            val raw = frameTimestampMs - prevTs
+            if (raw < 0L) 0L else raw
+        } else {
+            0L
+        }
+        lastTimestampMs = frameTimestampMs
+
+        val hasValidEar = avgEar != null && avgEar > 0f
+
+        // 4) 유효 EAR 가 있는 프레임에서만 워밍업 시간 누적
+        if (hasValidEar) {
+            warmupElapsedMs += deltaMs
         }
 
-        // 4) 눈 뜬 상태에서만 baselineEAR를 천천히 업데이트
-        if (!bothClosedNow && avgEar != null && avgEar > 0f) {
+        val inWarmup = warmupElapsedMs < warmupDurationMs
+
+        // 5) 눈 뜬 상태에서만 baselineEAR 업데이트
+        if (!bothClosedNow && hasValidEar) {
             baselineEar = if (baselineEar == 0f) {
-                avgEar               // 첫 값은 그대로 사용
+                avgEar!!
             } else {
-                // 지수 이동 평균 형태 (과거 baseline을 조금 남기고 최신 avgEar를 조금 섞음)
-                baselineEar * (1f - baselineSmoothing) + avgEar * baselineSmoothing
+                // 🔹 워밍업 구간에서는 더 큰 학습률, 이후에는 작은 학습률 사용
+                val alpha = if (inWarmup) warmupBaselineSmoothing else baselineSmoothing
+                baselineEar * (1f - alpha) + avgEar!! * alpha
             }
         }
 
-        // 5) 워밍업 구간인지 체크
-        val inWarmup = processedFrameCount < warmupFrameThreshold
-
+        // 6) 워밍업 구간 동안에는 상태를 무조건 NORMAL 로 고정
         if (inWarmup) {
-            // 워밍업 동안에는 상태를 무조건 NORMAL 로 고정
-            //    (이때 baselineEar 만 학습되는 느낌)
-            closedFrameCount = 0
-            openFrameCount = 0
+            closedDurationMs = 0L
+            openDurationMs = 0L
             state = DrowsinessState.NORMAL
             return state
         }
 
-        // 6) 워밍업 이후부터는 본격적으로 감김/뜸 프레임 카운트 관리
-        if (bothClosedNow) {
-            closedFrameCount++
-            openFrameCount = 0
-        } else {
-            openFrameCount++
-            closedFrameCount = 0
+        // 7) 워밍업 이후부터는 본격적으로 감김/뜸 "시간" 누적
+        if (hasValidEar) {
+            if (bothClosedNow) {
+                closedDurationMs += deltaMs
+                openDurationMs = 0L
+            } else {
+                openDurationMs += deltaMs
+                closedDurationMs = 0L
+            }
         }
 
-        // 7) 감긴 프레임 수에 따라 졸음/수면 상태 진입
+        // 8) 감긴 시간에 따라 졸음/수면 상태 진입
         state = when {
-            bothClosedNow && closedFrameCount >= sleepingFrameThreshold ->
+            bothClosedNow && closedDurationMs >= sleepingDurationMs ->
                 DrowsinessState.SLEEPING
-            bothClosedNow && closedFrameCount >= drowsyFrameThreshold ->
+            bothClosedNow && closedDurationMs >= drowsyDurationMs ->
                 DrowsinessState.DROWSY
             else -> state   // 그 외에는 이전 상태 유지
         }
 
-        // 8) 눈 뜬 상태가 일정 프레임 이상 유지되면 무조건 NORMAL 복귀
-        if (!bothClosedNow && openFrameCount >= recoverFrameThreshold) {
+        // 9) 눈 뜬 상태가 일정 시간 이상 유지되면 NORMAL 복귀
+        if (!bothClosedNow && openDurationMs >= recoverDurationMs) {
             state = DrowsinessState.NORMAL
         }
 
@@ -120,9 +140,10 @@ class DrowsinessDetector(
 
     fun reset() {
         baselineEar = 0f
-        closedFrameCount = 0
-        openFrameCount = 0
-        processedFrameCount = 0
+        lastTimestampMs = null
+        warmupElapsedMs = 0L
+        closedDurationMs = 0L
+        openDurationMs = 0L
         state = DrowsinessState.NORMAL
     }
 }

--- a/app/src/main/java/ac/sbmax002/eye_on/model/pipeline/FaceProcessingPipeline.kt
+++ b/app/src/main/java/ac/sbmax002/eye_on/model/pipeline/FaceProcessingPipeline.kt
@@ -92,8 +92,12 @@ class FaceProcessingPipeline(
         val rightEar = eyeRoi.rightEyePoints.takeIf { it.isNotEmpty() }
             ?.let { earCalculator.calculateEar(it) }
 
-        // 4. 졸음 상태 업데이트 (3단계)
-        val drowsinessState = drowsinessDetector.update(leftEar, rightEar)
+        // 4. 졸음 상태 업데이트
+        val drowsinessState = drowsinessDetector.update(
+            leftEar = leftEar,
+            rightEar = rightEar,
+            frameTimestampMs = faceResult.timestampMs() // MediaPipe 가 주는 timestamp (ms)
+        )
 
         // 5. ViewModel에 넘겨줄 DTO 만들기
         val result = PipelineResult(

--- a/app/src/main/java/ac/sbmax002/eye_on/repository/StatisticsRepository.kt
+++ b/app/src/main/java/ac/sbmax002/eye_on/repository/StatisticsRepository.kt
@@ -45,7 +45,7 @@ class StatisticsRepository(private val statisticsDao: StatisticsDao) {
     }
 
     // 4. 졸음 이벤트 발생 시: 이벤트 저장 + 세션 경고 횟수 증가
-    suspend fun saveEvent(sessionId: String, message: String, level: Int) {
+    suspend fun saveEvent(sessionId: String, message: String, level: Int, duration: String = "") {
         val now = LocalDateTime.now()
 
         // 이벤트 테이블에 기록
@@ -53,7 +53,7 @@ class StatisticsRepository(private val statisticsDao: StatisticsDao) {
             sessionId = sessionId,
             time = now.format(DateTimeFormatter.ofPattern("HH:mm:ss")),
             message = message,
-            duration = "0s", // 지속 시간 로직 필요시 수정
+            duration = duration,
             level = level
         )
         statisticsDao.insertEvent(event)

--- a/app/src/main/java/ac/sbmax002/eye_on/service/MonitoringService.kt
+++ b/app/src/main/java/ac/sbmax002/eye_on/service/MonitoringService.kt
@@ -37,6 +37,12 @@ class MonitoringService : Service(), PipelineListener {
     private var floatingWindowManager: FloatingWindowManager? = null
     
     private var isMonitoringStarted = false
+
+    // 파이프라인 결과를 Activity/HomeViewModel로 전달하기 위한 콜백
+    private var pipelineResultListener: ((PipelineResult) -> Unit)? = null
+    fun setOnPipelineResultListener(listener: ((PipelineResult) -> Unit)?) {
+        pipelineResultListener = listener
+    }
     
     // Service 바인딩을 위한 Binder
     inner class MonitoringBinder : Binder() {
@@ -140,6 +146,7 @@ class MonitoringService : Service(), PipelineListener {
     
     override fun onDestroy() {
         super.onDestroy()
+        pipelineResultListener = null
         Log.d(TAG, "MonitoringService onDestroy")
         stopMonitoring()
     }
@@ -193,6 +200,10 @@ class MonitoringService : Service(), PipelineListener {
         Log.d(TAG, "Pipeline result: drowsinessState=${result.drowsinessState}, faceDetected=${result.isFaceDetected}")
         // 졸음 상태에 따른 플로팅 아이콘 업데이트
         floatingWindowManager?.updateDrowsinessState(result.drowsinessState)
+
+        // Activity/HomeViewModel 쪽으로도 결과 전달
+        pipelineResultListener?.invoke(result)
+
         // TODO: 사운드 재생 (나중에 구현)
     }
     

--- a/app/src/main/java/ac/sbmax002/eye_on/statistics/DrivingSession.kt
+++ b/app/src/main/java/ac/sbmax002/eye_on/statistics/DrivingSession.kt
@@ -1,0 +1,17 @@
+package ac.sbmax002.eye_on.statistics
+
+import java.time.LocalDateTime
+
+data class DrivingSession(
+    val id: String,
+    val dateStr: String,   // 표시용 날짜 "2024-11-25"
+    val time: String,      // 시작 시간 "14:30"
+    val location: String,  // 위치
+    val durationMinutes: Int, // 계산용 분 (통계 합산용)
+    val durationStr: String,  // 표시용 "2h 15m" (DetailScreen 등에서 사용)
+    val level1Alerts: Int,
+    val level2Alerts: Int,
+    val rawDateTime: LocalDateTime, // 정렬 및 필터링용
+    val events: List<SessionEvent> = emptyList()
+)
+

--- a/app/src/main/java/ac/sbmax002/eye_on/statistics/SessionEvent.kt
+++ b/app/src/main/java/ac/sbmax002/eye_on/statistics/SessionEvent.kt
@@ -1,0 +1,9 @@
+package ac.sbmax002.eye_on.statistics
+
+data class SessionEvent(
+    val time: String,      // 발생 시각 (예: "14:22")
+    val message: String,   // 메시지
+    val duration: String,  // 지속 시간
+    val level: Int         // 1: 주의(Yellow), 2: 경고(Red)
+)
+

--- a/app/src/main/java/ac/sbmax002/eye_on/statistics/StatisticsUiState.kt
+++ b/app/src/main/java/ac/sbmax002/eye_on/statistics/StatisticsUiState.kt
@@ -1,0 +1,12 @@
+package ac.sbmax002.eye_on.statistics
+
+data class StatisticsUiState(
+    val selectedFilter: String = "주간",
+    val totalDrivingMinutes: Int = 0,
+    val totalSessions: Int = 0,
+    val level1Total: Int = 0,
+    val level2Total: Int = 0,
+    val timeDistribution: List<Int> = listOf(0, 0, 0, 0), // [오전, 오후, 저녁, 새벽]
+    val sessions: List<DrivingSession> = emptyList()
+)
+

--- a/app/src/main/java/ac/sbmax002/eye_on/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/ac/sbmax002/eye_on/ui/home/HomeViewModel.kt
@@ -20,6 +20,15 @@ class HomeViewModel(
     // 현재 실행 중인 세션 ID (DB 저장용)
     private var currentSessionId: String? = null
 
+    // 🔹 졸음 에피소드 추적용 상태
+    // NORMAL -> DROWSY/SLEEPING 진입 시 에피소드 시작,
+    // 다시 NORMAL 될 때 에피소드 종료
+    private var isInAlertState: Boolean = false          // 현재 에피소드 안에 있는지
+    private var alertStartTimestampMs: Long = 0L         // 에피소드 시작 프레임 timestamp
+    private var alertMaxLevel: Int = 0                   // 이 에피소드 동안 도달한 최대 레벨(1/2)
+    private var totalDrowsyDurationMs: Long = 0L         // 세션 동안 누적 졸음 시간(필요시 사용)
+
+
     // HomeUiState 초기값을 AppStateRepository의 현재 값과 동기화
     private val _uiState = MutableStateFlow(
         HomeUiState(appMode = AppStateRepository.getCurrentAppMode())
@@ -47,6 +56,12 @@ class HomeViewModel(
             currentSessionId = repository.startDrivingSession(currentMode)
             Log.d("HomeViewModel", "DB Session Created: $currentSessionId")
 
+            // 🔹 졸음 에피소드 상태 초기화
+            isInAlertState = false
+            alertStartTimestampMs = 0L
+            alertMaxLevel = 0
+            totalDrowsyDurationMs = 0L
+
             _uiState.value = _uiState.value.copy(
                 isMonitoring = true,
                 monitoringStartTime = System.currentTimeMillis(),
@@ -66,6 +81,12 @@ class HomeViewModel(
                 Log.d("HomeViewModel", "DB Session Ended: $sessionId")
             }
             currentSessionId = null
+
+            // 🔹 에피소드 상태 리셋
+            isInAlertState = false
+            alertStartTimestampMs = 0L
+            alertMaxLevel = 0
+            totalDrowsyDurationMs = 0L
 
             val monitoringDuration = if (_uiState.value.monitoringStartTime > 0) {
                 System.currentTimeMillis() - _uiState.value.monitoringStartTime
@@ -91,19 +112,82 @@ class HomeViewModel(
         // UI 업데이트: 얼굴 감지 상태 등
         updateFaceDetection(result.isFaceDetected)
 
-// ★ [수정됨] 상태에 따라 위험 레벨(Level) 결정
+        val state = result.drowsinessState
+
+        // 지금 프레임이 "경고 상태"인지 여부 (DROWSY 또는 SLEEPING)
+        val isAlertNow =
+            (state == DrowsinessState.DROWSY || state == DrowsinessState.SLEEPING)
+
+        // ★ [수정됨] 상태에 따라 위험 레벨(Level) 결정
         // DrowsinessDetector.kt와 PipeLineResult.kt에 정의된 상태를 사용
-        val alertLevel = when (result.drowsinessState) {
+        val alertLevel = when (state) {
             DrowsinessState.DROWSY -> 1   // 조금 졸림 -> Level 1
             DrowsinessState.SLEEPING -> 2 // 완전히 잠 -> Level 2
             else -> 0                     // 정상 -> 저장 안 함
         }
+// 1) NORMAL → DROWSY/SLEEPING : 에피소드 시작
+        if (isAlertNow && !isInAlertState) {
+            isInAlertState = true
+            alertStartTimestampMs = result.frameTimestampMs
+            alertMaxLevel = alertLevel
+            Log.d(
+                "HomeViewModel",
+                "Drowsiness episode started: level=$alertLevel, ts=${result.frameTimestampMs}"
+            )
+        }
+        // 2) 에피소드 진행 중: 더 높은 레벨이 나오면 갱신
+        else if (isAlertNow && isInAlertState) {
+            if (alertLevel > alertMaxLevel) {
+                alertMaxLevel = alertLevel
+            }
+        }
+        // 3) DROWSY/SLEEPING → NORMAL : 에피소드 종료
+        else if (!isAlertNow && isInAlertState) {
+            val endTs = result.frameTimestampMs
+            val durationMs = (endTs - alertStartTimestampMs).coerceAtLeast(0L)
 
-        // 위험 상황(1, 2)일 때만 저장 로직 실행
-        if (alertLevel > 0) {
-            incrementDrowsinessCount(alertLevel)
+            totalDrowsyDurationMs += durationMs
+
+            onDrowsinessEpisodeFinished(alertMaxLevel, durationMs)
+
+            // 상태 리셋
+            isInAlertState = false
+            alertStartTimestampMs = 0L
+            alertMaxLevel = 0
         }
     }
+
+    /**
+     * 졸음 에피소드가 끝났을 때 한 번만 호출:
+     * - DB에 SessionEvent 한 줄 저장
+     * - duration을 "1.2s" 같은 문자열로 포맷해서 넣어줌
+     */
+    private fun onDrowsinessEpisodeFinished(level: Int, durationMs: Long) {
+        val sessionId = currentSessionId ?: return
+        if (level <= 0) return
+
+        // ms → 초 단위 문자열로 변환 (예: 1250ms -> "1.3s")
+        val durationSeconds = durationMs / 1000f
+        val durationStr = String.format("%.1fs", durationSeconds)
+
+        val message = if (level == 2) "Sleep Detected" else "Drowsiness Detected"
+
+        Log.d(
+            "HomeViewModel",
+            "Drowsiness episode finished: level=$level, duration=$durationStr"
+        )
+
+        viewModelScope.launch {
+            repository.saveEvent(
+                sessionId = sessionId,
+                message = message,
+                level = level,
+                duration = durationStr
+            )
+        }
+    }
+
+
 
     // 내부적으로 카운트 증가 및 DB 저장
     private fun incrementDrowsinessCount(level: Int) {


### PR DESCRIPTION
## 📝 개요
- 모니터링 하면서 모델에서 나오는 결과 값들 디비에 저장. 
- 졸음 레벨, 졸음 횟수, 졸았던 시간

## 🔧 주요 작업(변경) 사항
1. **Room 데이터베이스 도입 및 스키마 정의**

   * `DrivingSession`, `SessionEvent` 엔티티 추가

     * `driving_sessions` : 세션 요약 정보(시작 시간, 모드, 총 운행 시간, 경고 횟수 등) 저장
     * `session_events` : 세션 내 졸음 이벤트 로그(메시지, 발생 시각, 레벨, 지속 시간 등) 저장
   * `Converters`로 `LocalDateTime`, `AppMode`를 문자열로 변환해 Room에서 사용할 수 있도록 처리
   * `AppDatabase` 싱글톤 구성 (`eye_on_database`) 및 `statisticsDao()` 제공

2. **통계용 DAO / Repository 계층 추가**

   * `StatisticsDao`에서 세션/이벤트 CRUD 및 조회 쿼리 정의
     (`insertSession`, `updateSession`, `insertEvent`, `getAllSessions`, `getEventsForSession` 등)
   * `StatisticsRepository`에서

     * 모니터링 시작 시 `DrivingSession` 생성 (`startDrivingSession`)
     * 모니터링 종료 시 세션 길이 계산 후 `durationMinutes`, `durationStr` 업데이트 (`endDrivingSession`)
     * 졸음 이벤트 발생 시 `SessionEvent` 저장 + 세션의 `level1Alerts` / `level2Alerts` 카운트 갱신 (`saveEvent`)
     * 통계/상세 화면에서 사용할 세션 목록 및 이벤트 조회 API 제공

3. **졸음 에피소드 단위 DB 로깅**

   * `HomeViewModel`에서 NORMAL ↔ DROWSY/SLEEPING 전이를 기준으로 졸음 에피소드 추적
   * 에피소드 종료 시 한 번만 `StatisticsRepository.saveEvent()` 호출하여

     * `session_events`에 이벤트 1건 삽입
     * `duration` 컬럼에 `"1.2s"` 형태로 졸음 지속 시간(초 단위)을 저장
   * 동일 시점에 `DrivingSession`의 경고 횟수(`level1Alerts`, `level2Alerts`)가 함께 집계되도록 연동

4. **통계 화면 데이터 소스 Room 연동**

   * 기존 Mock 데이터 대신 `StatisticsRepository.allSessions`를 구독하도록 `StatisticsViewModel`를 수정하여
     통계/상세 화면이 Room DB에 저장된 실제 세션/이벤트 데이터를 기준으로 렌더링되도록 변경


## 🎥 스크린샷/데모 (선택)
<img width="1497" height="95" alt="image" src="https://github.com/user-attachments/assets/1bb522ae-44d1-40df-a78c-a6de5de6d072" />
<img width="1429" height="569" alt="image" src="https://github.com/user-attachments/assets/76fd3653-550a-4606-b640-24357845d7e6" />


## 🔗 이슈 연결
- EYE- 57

## ✅ 체크리스트
- [x] merge branch 가 dev인가?
- [x] 제목이 "[TYPE] [EYE-XX] 작업 개요"형태인가
- [x] 테스트 했는가?
- [x] 의존성이 있는 코드를 빠뜨리진 않았는가?
