### PR TITLE
[FIX] [EYE-63] fix store and load settings value and preview sound

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -95,5 +95,8 @@ dependencies {
     implementation(libs.androidx.room.runtime)
     implementation(libs.androidx.room.ktx)
     ksp(libs.androidx.room.compiler)
+    
+    // DataStore - 설정값 저장
+    implementation(libs.androidx.datastore.preferences)
 
 }

--- a/app/src/main/java/ac/sbmax002/eye_on/repository/SettingsRepository.kt
+++ b/app/src/main/java/ac/sbmax002/eye_on/repository/SettingsRepository.kt
@@ -1,0 +1,131 @@
+package ac.sbmax002.eye_on.repository
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import ac.sbmax002.eye_on.ui.settings.AlarmSound
+import ac.sbmax002.eye_on.ui.settings.FloatingIconSize
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * 설정값을 DataStore에 저장하고 불러오는 Repository
+ * DataStore (Preferences)를 사용하여 설정값을 영구적으로 저장
+ */
+@Singleton
+class SettingsRepository @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    // DataStore 인스턴스 생성 (Context 확장 함수 사용)
+    private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "settings")
+    
+    // Preference 키 정의
+    private object Keys {
+        val LEVEL1_ALARM_SOUND = stringPreferencesKey("level1_alarm_sound")
+        val LEVEL1_VOLUME = intPreferencesKey("level1_volume")
+        val LEVEL2_ALARM_SOUND = stringPreferencesKey("level2_alarm_sound")
+        val LEVEL2_VOLUME = intPreferencesKey("level2_volume")
+        val FLOATING_ICON_SIZE = stringPreferencesKey("floating_icon_size")
+        val VIBRATION_ENABLED = intPreferencesKey("vibration_enabled") // Boolean을 Int로 저장 (0=false, 1=true)
+        val DARK_MODE_ENABLED = intPreferencesKey("dark_mode_enabled")
+    }
+    
+    // 졸음 경고 1단계 알림음
+    val level1AlarmSound: Flow<AlarmSound> = context.dataStore.data.map { preferences ->
+        val soundName = preferences[Keys.LEVEL1_ALARM_SOUND] ?: AlarmSound.BELL_NOTIFICATION.name
+        try {
+            AlarmSound.valueOf(soundName)
+        } catch (e: IllegalArgumentException) {
+            AlarmSound.BELL_NOTIFICATION
+        }
+    }
+    
+    suspend fun saveLevel1AlarmSound(sound: AlarmSound) {
+        context.dataStore.edit { preferences ->
+            preferences[Keys.LEVEL1_ALARM_SOUND] = sound.name
+        }
+    }
+    
+    // 졸음 경고 1단계 음량
+    val level1Volume: Flow<Int> = context.dataStore.data.map { preferences ->
+        preferences[Keys.LEVEL1_VOLUME] ?: 70
+    }
+    
+    suspend fun saveLevel1Volume(volume: Int) {
+        context.dataStore.edit { preferences ->
+            preferences[Keys.LEVEL1_VOLUME] = volume.coerceIn(0, 100)
+        }
+    }
+    
+    // 수면 경고 2단계 알림음
+    val level2AlarmSound: Flow<AlarmSound> = context.dataStore.data.map { preferences ->
+        val soundName = preferences[Keys.LEVEL2_ALARM_SOUND] ?: AlarmSound.SIREN.name
+        try {
+            AlarmSound.valueOf(soundName)
+        } catch (e: IllegalArgumentException) {
+            AlarmSound.SIREN
+        }
+    }
+    
+    suspend fun saveLevel2AlarmSound(sound: AlarmSound) {
+        context.dataStore.edit { preferences ->
+            preferences[Keys.LEVEL2_ALARM_SOUND] = sound.name
+        }
+    }
+    
+    // 수면 경고 2단계 음량
+    val level2Volume: Flow<Int> = context.dataStore.data.map { preferences ->
+        preferences[Keys.LEVEL2_VOLUME] ?: 100
+    }
+    
+    suspend fun saveLevel2Volume(volume: Int) {
+        context.dataStore.edit { preferences ->
+            preferences[Keys.LEVEL2_VOLUME] = volume.coerceIn(0, 100)
+        }
+    }
+    
+    // 플로팅 아이콘 크기
+    val floatingIconSize: Flow<FloatingIconSize> = context.dataStore.data.map { preferences ->
+        val sizeName = preferences[Keys.FLOATING_ICON_SIZE] ?: FloatingIconSize.MEDIUM.name
+        try {
+            FloatingIconSize.valueOf(sizeName)
+        } catch (e: IllegalArgumentException) {
+            FloatingIconSize.MEDIUM
+        }
+    }
+    
+    suspend fun saveFloatingIconSize(size: FloatingIconSize) {
+        context.dataStore.edit { preferences ->
+            preferences[Keys.FLOATING_ICON_SIZE] = size.name
+        }
+    }
+    
+    // 진동 알림
+    val vibrationEnabled: Flow<Boolean> = context.dataStore.data.map { preferences ->
+        (preferences[Keys.VIBRATION_ENABLED] ?: 1) == 1
+    }
+    
+    suspend fun saveVibrationEnabled(enabled: Boolean) {
+        context.dataStore.edit { preferences ->
+            preferences[Keys.VIBRATION_ENABLED] = if (enabled) 1 else 0
+        }
+    }
+    
+    // 다크 모드
+    val darkModeEnabled: Flow<Boolean> = context.dataStore.data.map { preferences ->
+        (preferences[Keys.DARK_MODE_ENABLED] ?: 1) == 1
+    }
+    
+    suspend fun saveDarkModeEnabled(enabled: Boolean) {
+        context.dataStore.edit { preferences ->
+            preferences[Keys.DARK_MODE_ENABLED] = if (enabled) 1 else 0
+        }
+    }
+}

--- a/app/src/main/java/ac/sbmax002/eye_on/ui/settings/Level1AlertScreen.kt
+++ b/app/src/main/java/ac/sbmax002/eye_on/ui/settings/Level1AlertScreen.kt
@@ -1,5 +1,6 @@
 package ac.sbmax002.eye_on.ui.settings
 
+import android.annotation.SuppressLint
 import android.media.AudioManager
 import android.media.MediaPlayer
 import android.util.Log
@@ -22,8 +23,8 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.lifecycle.viewmodel.compose.viewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
@@ -36,7 +37,7 @@ import kotlinx.coroutines.launch
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun Level1AlertScreen(
-    viewModel: SettingsViewModel = viewModel(),
+    viewModel: SettingsViewModel = hiltViewModel(),
     onNavigateBack: () -> Unit
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -44,13 +45,9 @@ fun Level1AlertScreen(
     val scope = rememberCoroutineScope()
     val primaryColor = MaterialTheme.colorScheme.primary
     
-    // 현재 선택된 알림음 (기존 값이 deprecated면 새 값으로 변환)
-    val initialSound = when (uiState.level1AlarmSound) {
-        AlarmSound.CHIME -> AlarmSound.BELL_NOTIFICATION
-        AlarmSound.SIREN_OLD -> AlarmSound.SIREN
-        else -> uiState.level1AlarmSound
-    }
-    var selectedSound by remember { mutableStateOf(initialSound) }
+    // 현재 저장된 설정값으로 선택값 동기화
+    val initialSound = normalizeAlarmSound(uiState.level1AlarmSound)
+    var selectedSound by remember(initialSound) { mutableStateOf(initialSound) }
     
     // 미리듣기 관련 상태
     var playingSound by remember { mutableStateOf<AlarmSound?>(null) }
@@ -282,11 +279,20 @@ private fun AlarmSoundItem(
     }
 }
 
+private fun normalizeAlarmSound(sound: AlarmSound): AlarmSound {
+    return when (sound.name) {
+        "CHIME" -> AlarmSound.BELL_NOTIFICATION
+        "SIREN_OLD" -> AlarmSound.SIREN
+        else -> sound
+    }
+}
+
 /**
  * 미리듣기 소리 재생
  * 재생 버튼 클릭 시에만 호출됩니다.
  * 최대 5초간 재생하고 자동으로 멈춥니다.
  */
+@SuppressLint("DiscouragedApi") // getIdentifier 사용 경고 억제 (동적 리소스 이름 지원)
 private suspend fun playPreviewSound(
     context: android.content.Context,
     sound: AlarmSound,

--- a/app/src/main/java/ac/sbmax002/eye_on/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/ac/sbmax002/eye_on/ui/settings/SettingsScreen.kt
@@ -1,6 +1,5 @@
 package ac.sbmax002.eye_on.ui.settings
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
@@ -13,7 +12,6 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp

--- a/app/src/main/java/ac/sbmax002/eye_on/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/ac/sbmax002/eye_on/ui/settings/SettingsScreen.kt
@@ -18,8 +18,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.lifecycle.viewmodel.compose.viewModel
 
 /**
  * 설정 화면
@@ -30,7 +30,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingsScreen(
-    viewModel: SettingsViewModel = viewModel(),
+    viewModel: SettingsViewModel = hiltViewModel(),
     onNavigateBack: () -> Unit,
     onNavigateToLevel1Alert: () -> Unit = {}
 ) {
@@ -109,12 +109,6 @@ fun SettingsScreen(
                 )
                 
                 Spacer(modifier = Modifier.height(16.dp))
-                
-                SettingToggleItem(
-                    label = "다크 모드",
-                    checked = uiState.darkModeEnabled,
-                    onCheckedChange = { viewModel.toggleDarkMode() }
-                )
             }
         }
     }

--- a/app/src/main/java/ac/sbmax002/eye_on/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/ac/sbmax002/eye_on/ui/settings/SettingsViewModel.kt
@@ -2,10 +2,12 @@ package ac.sbmax002.eye_on.ui.settings
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import ac.sbmax002.eye_on.repository.SettingsRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -14,19 +16,80 @@ import javax.inject.Inject
  * 
  * MVVM 패턴에 따라 UI 상태를 관리하고 비즈니스 로직을 처리합니다.
  * Hilt를 사용하여 의존성 주입을 받습니다.
+ * DataStore를 통해 설정값을 영구적으로 저장
  */
 @HiltViewModel
-class SettingsViewModel @Inject constructor() : ViewModel() {
+class SettingsViewModel @Inject constructor(
+    private val settingsRepository: SettingsRepository
+) : ViewModel() {
     
+    /**
+     * DataStore에서 가져온 핵심 설정값 묶음
+     */
+    private data class CoreSettings(
+        val level1Sound: AlarmSound,
+        val level1Volume: Int,
+        val level2Sound: AlarmSound,
+        val level2Volume: Int,
+        val iconSize: FloatingIconSize
+    )
+
     private val _uiState = MutableStateFlow(SettingsUiState())
     val uiState: StateFlow<SettingsUiState> = _uiState.asStateFlow()
+    
+    init {
+        // 초기화 시 저장된 설정값 불러오기
+        loadSettings()
+    }
+    
+    /**
+     * 저장된 설정값을 불러와서 UI 상태에 반영
+     */
+    private fun loadSettings() {
+        viewModelScope.launch {
+            combine(
+                combine(
+                    settingsRepository.level1AlarmSound,
+                    settingsRepository.level1Volume,
+                    settingsRepository.level2AlarmSound,
+                    settingsRepository.level2Volume,
+                    settingsRepository.floatingIconSize
+                ) { level1Sound, level1Vol, level2Sound, level2Vol, iconSize ->
+                    CoreSettings(
+                        level1Sound = level1Sound,
+                        level1Volume = level1Vol,
+                        level2Sound = level2Sound,
+                        level2Volume = level2Vol,
+                        iconSize = iconSize
+                    )
+                },
+                settingsRepository.vibrationEnabled,
+                settingsRepository.darkModeEnabled
+            ) { core, vibration, darkMode ->
+                SettingsUiState(
+                    level1AlarmSound = core.level1Sound,
+                    level1Volume = core.level1Volume,
+                    level2AlarmSound = core.level2Sound,
+                    level2Volume = core.level2Volume,
+                    floatingIconSize = core.iconSize,
+                    vibrationEnabled = vibration,
+                    darkModeEnabled = darkMode
+                )
+            }.collect { state ->
+                _uiState.value = state
+            }
+        }
+    }
     
     /**
      * 졸음 경고 1단계 알림음 변경
      */
     fun updateLevel1AlarmSound(sound: AlarmSound) {
         _uiState.value = _uiState.value.copy(level1AlarmSound = sound)
-        // TODO: 실제 설정 저장 로직 추가 (SharedPreferences 또는 DataStore)
+        // DataStore에 저장
+        viewModelScope.launch {
+            settingsRepository.saveLevel1AlarmSound(sound)
+        }
     }
     
     /**
@@ -35,7 +98,10 @@ class SettingsViewModel @Inject constructor() : ViewModel() {
     fun updateLevel1Volume(volume: Int) {
         val clampedVolume = volume.coerceIn(0, 100)
         _uiState.value = _uiState.value.copy(level1Volume = clampedVolume)
-        // TODO: 실제 설정 저장 로직 추가
+        // DataStore에 저장
+        viewModelScope.launch {
+            settingsRepository.saveLevel1Volume(clampedVolume)
+        }
     }
     
     /**
@@ -43,7 +109,10 @@ class SettingsViewModel @Inject constructor() : ViewModel() {
      */
     fun updateLevel2AlarmSound(sound: AlarmSound) {
         _uiState.value = _uiState.value.copy(level2AlarmSound = sound)
-        // TODO: 실제 설정 저장 로직 추가
+        // DataStore에 저장
+        viewModelScope.launch {
+            settingsRepository.saveLevel2AlarmSound(sound)
+        }
     }
     
     /**
@@ -52,7 +121,10 @@ class SettingsViewModel @Inject constructor() : ViewModel() {
     fun updateLevel2Volume(volume: Int) {
         val clampedVolume = volume.coerceIn(0, 100)
         _uiState.value = _uiState.value.copy(level2Volume = clampedVolume)
-        // TODO: 실제 설정 저장 로직 추가
+        // DataStore에 저장
+        viewModelScope.launch {
+            settingsRepository.saveLevel2Volume(clampedVolume)
+        }
     }
     
     /**
@@ -60,23 +132,34 @@ class SettingsViewModel @Inject constructor() : ViewModel() {
      */
     fun updateFloatingIconSize(size: FloatingIconSize) {
         _uiState.value = _uiState.value.copy(floatingIconSize = size)
-        // TODO: 실제 설정 저장 로직 추가
+        // DataStore에 저장
+        viewModelScope.launch {
+            settingsRepository.saveFloatingIconSize(size)
+        }
     }
     
     /**
      * 진동 알림 토글
      */
     fun toggleVibration() {
-        _uiState.value = _uiState.value.copy(vibrationEnabled = !_uiState.value.vibrationEnabled)
-        // TODO: 실제 설정 저장 로직 추가
+        val newValue = !_uiState.value.vibrationEnabled
+        _uiState.value = _uiState.value.copy(vibrationEnabled = newValue)
+        // DataStore에 저장
+        viewModelScope.launch {
+            settingsRepository.saveVibrationEnabled(newValue)
+        }
     }
     
     /**
      * 다크 모드 토글
      */
     fun toggleDarkMode() {
-        _uiState.value = _uiState.value.copy(darkModeEnabled = !_uiState.value.darkModeEnabled)
-        // TODO: 실제 설정 저장 로직 추가
+        val newValue = !_uiState.value.darkModeEnabled
+        _uiState.value = _uiState.value.copy(darkModeEnabled = newValue)
+        // DataStore에 저장
+        viewModelScope.launch {
+            settingsRepository.saveDarkModeEnabled(newValue)
+        }
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ compose-material-icons-extended = "1.7.5"
 camerax = "1.5.1"
 mediapipe = "0.10.26.1"
 hilt = "2.51.1"
+datastore = "1.1.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -65,6 +66,8 @@ hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-com
 androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
 androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
 androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
+# DataStore 라이브러리
+androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## 📝 개요
- 설정값 저장 

## 🔧 주요 작업(변경) 사항
- [ ] hilt로 SettingsVeiwModel 생성
- [ ] datastore 의존성 추가
- [ ] 설정값 변경 후 저장 시 해당 사항 preference datastore로 저장
- [ ] 알림음 미리 듣기에서 저장한 알림음으로 표시되게 ui 변경
- [ ] 알림음 미리 듣기에서 소리 겹치지 않게 수정

## 🎥 스크린샷/데모 (선택)
<이미지 또는 gif>

## 🔗 이슈 연결
- EYE-63

## ✅ 체크리스트
- [x] merge branch 가 dev인가?
- [x] 제목이 "[TYPE] [EYE-XX] 작업 개요"형태인가
- [x] 테스트 했는가?
- [x] 의존성이 있는 코드를 빠뜨리진 않았는가?
- [ ] 문서화 했는가?