### PR TITLE
[FIX] [EYE-73] Live StatisticsScreen Count Fix

### DIFF
--- a/app/src/main/java/ac/sbmax002/eye_on/ui/home/HomeUiState.kt
+++ b/app/src/main/java/ac/sbmax002/eye_on/ui/home/HomeUiState.kt
@@ -7,6 +7,7 @@ data class HomeUiState(
     val monitoringStartTime: Long = 0L,
     val lastSessionDuration: Long = 0L,
     val drowsinessDetectionCount: Int = 0,
+    val sleepDetectionCount: Int = 0,
     val appMode: AppMode = AppMode.DRIVING,
     val cameraInitialized: Boolean = false
 )

--- a/app/src/main/java/ac/sbmax002/eye_on/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/ac/sbmax002/eye_on/ui/home/HomeViewModel.kt
@@ -166,6 +166,7 @@ class HomeViewModel(
         val sessionId = currentSessionId ?: return
         if (level <= 0) return
 
+        incrementDrowsinessCount(level)
         // ms → 초 단위 문자열로 변환 (예: 1250ms -> "1.3s")
         val durationSeconds = durationMs / 1000f
         val durationStr = String.format("%.1fs", durationSeconds)
@@ -192,16 +193,23 @@ class HomeViewModel(
     // 내부적으로 카운트 증가 및 DB 저장
     private fun incrementDrowsinessCount(level: Int) {
         val sessionId = currentSessionId ?: return // 세션 없으면 무시
+            if (level <= 0) return
+
+            // 1. UI 카운트 증가
+            _uiState.value = if (level == 2) {
+                // Level 2 (수면)
+                _uiState.value.copy(
+                    sleepDetectionCount = _uiState.value.sleepDetectionCount + 1
+                )
+            } else {
+                // Level 1 (졸음)
+                _uiState.value.copy(
+                    drowsinessDetectionCount = _uiState.value.drowsinessDetectionCount + 1
+                )
+            }
+
 
         viewModelScope.launch {
-            // 1. UI 업데이트 우영님 요청 사항 - 주석 처리
-           /*
-           _uiState.value = _uiState.value.copy(
-                drowsinessDetectionCount = _uiState.value.drowsinessDetectionCount + 1
-            )
-            */
-
-
 // 2. DB에 이벤트 저장 (Level에 따라 메시지 구분)
             val message = if (level == 2) "Sleep Detected" else "Drowsiness Detected"
 

--- a/app/src/main/java/ac/sbmax002/eye_on/ui/statistics/StatisticsScreen.kt
+++ b/app/src/main/java/ac/sbmax002/eye_on/ui/statistics/StatisticsScreen.kt
@@ -164,7 +164,7 @@ fun CurrentSessionView(
                 Spacer(modifier = Modifier.height(12.dp))
                 Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
                     Text(if(isDriving) "수면 경고 횟수" else "자리 비움 경고", color = Color.Gray)
-                    Text("0회", color = Color(0xFFE53935), fontSize = 18.sp, fontWeight = FontWeight.Bold)
+                    Text("${homeUiState.sleepDetectionCount}회", color = Color(0xFFE53935), fontSize = 18.sp, fontWeight = FontWeight.Bold)
                 }
             }
 


### PR DESCRIPTION
## 📝 개요
- 실시간 통계화면 카운트 연결 해결

## 🔧 주요 작업(변경) 사항
- 저번에 주석처리 해둔 실시간 함수값 받게 해서 실시간 통계 화면으로 연결
★실시간 통계화면 타임라인은 미작업★

다른 코드에 영향 최소한으로 갈수 있게 최대한 다른 부분 안건드렸는데 혹시 꼬이는거 있으면 알려주세요


## 🎥 스크린샷/데모 (선택)
<이미지 또는 gif>

## 🔗 이슈 연결
- EYE- 73

## ✅ 체크리스트
- [ ] merge branch 가 dev인가?
- [ ] 제목이 "[TYPE] [EYE-XX] 작업 개요"형태인가
- [ ] 테스트 했는가?
- [ ] 의존성이 있는 코드를 빠뜨리진 않았는가?
- [ ] 문서화 했는가?