### PR TITLE
[FEAT] EYE-87 API - localhost8080

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -100,4 +100,8 @@ dependencies {
     // DataStore - 설정값 저장
     implementation(libs.androidx.datastore.preferences)
 
+    // Retrofit & OkHttp
+    implementation(libs.retrofit.core)
+    implementation(libs.retrofit.gson)
+
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,6 +23,7 @@
     <application
         android:name=".EyeOnApplication"
         android:allowBackup="true"
+        android:usesCleartextTraffic="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/java/ac/sbmax002/eye_on/navigation/EyeOnNavigation.kt
+++ b/app/src/main/java/ac/sbmax002/eye_on/navigation/EyeOnNavigation.kt
@@ -39,8 +39,38 @@ fun EyeOnApp(
     // 네비게이션 호스트 (모든 화면을 여기서 관리)
     NavHost(
         navController = navController,
-        startDestination = Routes.HOME
+        startDestination = Routes.LOGIN
     ) {
+        // 로그인 화면
+        composable(Routes.LOGIN) {
+            ac.sbmax002.eye_on.ui.login.LoginScreen(
+                onNavigateToHome = {
+                    // 로그인 완료 후 홈 화면으로 이동하며, 뒤로가기 시 로그인 화면이 나오지 않도록 스택에서 제거
+                    navController.navigate(Routes.HOME) {
+                        popUpTo(Routes.LOGIN) { inclusive = true }
+                    }
+                },
+                onNavigateToSignUp = {
+                    navController.navigate(Routes.SIGN_UP)
+                }
+            )
+        }
+
+        // 회원가입 화면
+        composable(Routes.SIGN_UP) {
+            ac.sbmax002.eye_on.ui.login.SignUpScreen(
+                onNavigateToHome = {
+                    // 가입 완료 후 홈 화면으로 이동
+                    navController.navigate(Routes.HOME) {
+                        popUpTo(Routes.LOGIN) { inclusive = true }
+                    }
+                },
+                onNavigateBack = {
+                    navController.popBackStack()
+                }
+            )
+        }
+
         // 1. 홈 화면
         composable(Routes.HOME) {
             HomeScreen(

--- a/app/src/main/java/ac/sbmax002/eye_on/navigation/Routes.kt
+++ b/app/src/main/java/ac/sbmax002/eye_on/navigation/Routes.kt
@@ -8,6 +8,8 @@ package ac.sbmax002.eye_on.navigation
  * - navController.navigate("${Routes.DETAIL}/$sessionId")
  */
 object Routes {
+    const val LOGIN = "login"
+    const val SIGN_UP = "sign_up"
     const val HOME = "home"
     const val STATISTICS = "statistics"
     const val DETAIL = "detail"

--- a/app/src/main/java/ac/sbmax002/eye_on/network/AuthApiService.kt
+++ b/app/src/main/java/ac/sbmax002/eye_on/network/AuthApiService.kt
@@ -1,0 +1,24 @@
+package ac.sbmax002.eye_on.network
+
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+/**
+ * 인증 관련 API 인터페이스 (Swagger v1.0.0 반영)
+ * 헤더는 NetworkConfig의 Interceptor에서 공통 처리됨
+ */
+interface AuthApiService {
+    
+    @POST("/api/auth/login")
+    suspend fun login(@Body request: LoginRequest): Response<AuthTokenResponse>
+
+    @POST("/api/auth/signup")
+    suspend fun signUp(@Body request: SignupRequest): Response<AuthTokenResponse>
+
+    @POST("/api/auth/refresh")
+    suspend fun refresh(@Body request: TokenRequest): Response<AuthTokenResponse>
+
+    @POST("/api/auth/logout")
+    suspend fun logout(@Body request: TokenRequest): Response<SimpleResponse>
+}

--- a/app/src/main/java/ac/sbmax002/eye_on/network/AuthDto.kt
+++ b/app/src/main/java/ac/sbmax002/eye_on/network/AuthDto.kt
@@ -1,0 +1,47 @@
+package ac.sbmax002.eye_on.network
+
+/**
+ * 로그인/회원가입/토큰갱신 공통 응답 (AuthTokenResponse)
+ */
+data class AuthTokenResponse(
+    val userId: Long,
+    val accessToken: String,
+    val refreshToken: String,
+    val role: String // "ADMIN" | "USER"
+)
+
+/**
+ * 로그인 요청 (LoginRequest)
+ */
+data class LoginRequest(
+    val email: String,
+    val password: String
+)
+
+/**
+ * 회원가입 요청 (SignupRequest)
+ * organizationCode는 서버 DTO 호환을 위해 유지 (앱에서는 "" 전송)
+ */
+data class SignupRequest(
+    val email: String,
+    val password: String,
+    val organizationCode: String = "",
+    val name: String,
+    val nickname: String,
+    val age: Int,
+    val gender: String // "MALE" | "FEMALE"
+)
+
+/**
+ * 로그아웃/토큰갱신 요청 (LogoutRequest, RefreshRequest)
+ */
+data class TokenRequest(
+    val refreshToken: String
+)
+
+/**
+ * 일반 성공 여부 응답
+ */
+data class SimpleResponse(
+    val success: Boolean
+)

--- a/app/src/main/java/ac/sbmax002/eye_on/network/NetworkConfig.kt
+++ b/app/src/main/java/ac/sbmax002/eye_on/network/NetworkConfig.kt
@@ -1,0 +1,40 @@
+package ac.sbmax002.eye_on.network
+
+import okhttp3.Interceptor
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+/**
+ * 네트워크 관련 설정을 관리하는 객체
+ */
+object NetworkConfig {
+    /**
+     * 백엔드 서버의 기본 URL
+     */
+    const val BASE_URL = "http://localhost:8080"
+
+    // 모든 요청에 공통 헤더를 추가하는 인터셉터
+    private val commonHeaderInterceptor = Interceptor { chain ->
+        val original = chain.request()
+        val request = original.newBuilder()
+            .header("Accept", "application/json")
+            .header("Content-Type", "application/json")
+            .build()
+        chain.proceed(request)
+    }
+
+    private val client = OkHttpClient.Builder()
+        .addInterceptor(commonHeaderInterceptor)
+        .build()
+
+    val retrofit: Retrofit = Retrofit.Builder()
+        .baseUrl(BASE_URL)
+        .client(client)
+        .addConverterFactory(GsonConverterFactory.create())
+        .build()
+
+    val authApiService: AuthApiService by lazy {
+        retrofit.create(AuthApiService::class.java)
+    }
+}

--- a/app/src/main/java/ac/sbmax002/eye_on/ui/login/LoginScreen.kt
+++ b/app/src/main/java/ac/sbmax002/eye_on/ui/login/LoginScreen.kt
@@ -17,6 +17,11 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import ac.sbmax002.eye_on.network.NetworkConfig
+import ac.sbmax002.eye_on.network.LoginRequest
+import kotlinx.coroutines.launch
+import android.widget.Toast
+import androidx.compose.ui.platform.LocalContext
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -24,8 +29,10 @@ fun LoginScreen(
     onNavigateToHome: () -> Unit,
     onNavigateToSignUp: () -> Unit
 ) {
+    val context = LocalContext.current
     var email by remember { mutableStateOf("") }
     var password by remember { mutableStateOf("") }
+    val scope = rememberCoroutineScope()
 
     // 어두운 배경색 적용 (기존 앱 테마 유지)
     Surface(
@@ -91,7 +98,27 @@ fun LoginScreen(
             Spacer(modifier = Modifier.height(32.dp))
             
             AnimatedButtonLogin(
-                onClick = onNavigateToHome,
+                onClick = {
+                    if (email.isNotBlank() && password.isNotBlank()) {
+                        scope.launch {
+                            try {
+                                val response = NetworkConfig.authApiService.login(LoginRequest(email, password))
+                                if (response.isSuccessful) {
+                                    onNavigateToHome()
+                                } else {
+                                    val msg = when(response.code()) {
+                                        401 -> "이메일 또는 비밀번호가 틀렸습니다."
+                                        400 -> "입력값이 올바르지 않습니다."
+                                        else -> "로그인 실패: ${response.code()}"
+                                    }
+                                    Toast.makeText(context, msg, Toast.LENGTH_SHORT).show()
+                                }
+                            } catch (e: Exception) {
+                                Toast.makeText(context, "네트워크 연결을 확인해주세요.", Toast.LENGTH_SHORT).show()
+                            }
+                        }
+                    }
+                },
                 text = "로그인",
                 backgroundColor = Color(0xFF007AFF)
             )

--- a/app/src/main/java/ac/sbmax002/eye_on/ui/login/LoginScreen.kt
+++ b/app/src/main/java/ac/sbmax002/eye_on/ui/login/LoginScreen.kt
@@ -1,0 +1,153 @@
+package ac.sbmax002.eye_on.ui.login
+
+import androidx.compose.animation.core.*
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LoginScreen(
+    onNavigateToHome: () -> Unit,
+    onNavigateToSignUp: () -> Unit
+) {
+    var email by remember { mutableStateOf("") }
+    var password by remember { mutableStateOf("") }
+
+    // 어두운 배경색 적용 (기존 앱 테마 유지)
+    Surface(
+        modifier = Modifier.fillMaxSize(),
+        color = Color(0xFF1A1A1A)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Text(
+                text = "Eye:on",
+                fontSize = 40.sp,
+                fontWeight = FontWeight.Bold,
+                color = Color.White,
+                letterSpacing = (-1).sp
+            )
+            
+            Spacer(modifier = Modifier.height(48.dp))
+            
+            OutlinedTextField(
+                value = email,
+                onValueChange = { email = it },
+                label = { Text("이메일", color = Color(0xFF9E9E9E)) },
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(12.dp),
+                colors = OutlinedTextFieldDefaults.colors(
+                    focusedTextColor = Color.White,
+                    unfocusedTextColor = Color.White,
+                    focusedBorderColor = Color(0xFF007AFF),
+                    unfocusedBorderColor = Color(0xFF424242),
+                    focusedContainerColor = Color.Transparent,
+                    unfocusedContainerColor = Color.Transparent
+                ),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
+                singleLine = true
+            )
+            
+            Spacer(modifier = Modifier.height(16.dp))
+            
+            OutlinedTextField(
+                value = password,
+                onValueChange = { password = it },
+                label = { Text("비밀번호", color = Color(0xFF9E9E9E)) },
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(12.dp),
+                visualTransformation = PasswordVisualTransformation(),
+                colors = OutlinedTextFieldDefaults.colors(
+                    focusedTextColor = Color.White,
+                    unfocusedTextColor = Color.White,
+                    focusedBorderColor = Color(0xFF007AFF),
+                    unfocusedBorderColor = Color(0xFF424242),
+                    focusedContainerColor = Color.Transparent,
+                    unfocusedContainerColor = Color.Transparent
+                ),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                singleLine = true
+            )
+            
+            Spacer(modifier = Modifier.height(32.dp))
+            
+            AnimatedButtonLogin(
+                onClick = onNavigateToHome,
+                text = "로그인",
+                backgroundColor = Color(0xFF007AFF)
+            )
+            
+            Spacer(modifier = Modifier.height(16.dp))
+            
+            TextButton(onClick = onNavigateToSignUp) {
+                Text(
+                    text = "계정이 없으신가요? 회원가입",
+                    color = Color(0xFF007AFF),
+                    fontSize = 14.sp
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun AnimatedButtonLogin(
+    onClick: () -> Unit,
+    text: String,
+    backgroundColor: Color,
+    modifier: Modifier = Modifier
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isPressed by interactionSource.collectIsPressedAsState()
+
+    val scale by animateFloatAsState(
+        targetValue = if (isPressed) 0.96f else 1f,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioMediumBouncy,
+            stiffness = Spring.StiffnessMedium
+        ),
+        label = "button_scale"
+    )
+
+    Button(
+        onClick = onClick,
+        modifier = modifier
+            .fillMaxWidth()
+            .height(56.dp)
+            .graphicsLayer {
+                scaleX = scale
+                scaleY = scale
+            },
+        colors = ButtonDefaults.buttonColors(
+            containerColor = backgroundColor
+        ),
+        shape = RoundedCornerShape(16.dp),
+        interactionSource = interactionSource
+    ) {
+        Text(
+            text = text,
+            fontSize = 18.sp,
+            fontWeight = FontWeight.Bold,
+            color = Color.White
+        )
+    }
+}

--- a/app/src/main/java/ac/sbmax002/eye_on/ui/login/SignUpScreen.kt
+++ b/app/src/main/java/ac/sbmax002/eye_on/ui/login/SignUpScreen.kt
@@ -1,0 +1,231 @@
+package ac.sbmax002.eye_on.ui.login
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SignUpScreen(
+    onNavigateToHome: () -> Unit,
+    onNavigateBack: () -> Unit
+) {
+    var email by remember { mutableStateOf("") }
+    var password by remember { mutableStateOf("") }
+    var name by remember { mutableStateOf("") }
+    var nickname by remember { mutableStateOf("") }
+    
+    // 나이(년도) 드롭다운 상태
+    var expandedYear by remember { mutableStateOf(false) }
+    var selectedYear by remember { mutableStateOf("") }
+    val years = (1950..2024).map { it.toString() }.reversed()
+
+    // 성별 상태
+    val genderOptions = listOf("남", "여")
+    var selectedGender by remember { mutableStateOf(genderOptions[0]) }
+
+    val scrollState = rememberScrollState()
+
+    // 어두운 배경색 적용
+    Surface(
+        modifier = Modifier.fillMaxSize(),
+        color = Color(0xFF1A1A1A)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 24.dp)
+                .verticalScroll(scrollState),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Spacer(modifier = Modifier.height(48.dp))
+            
+            Text(
+                text = "회원가입",
+                fontSize = 32.sp,
+                fontWeight = FontWeight.Bold,
+                color = Color.White
+            )
+            
+            Spacer(modifier = Modifier.height(48.dp))
+            
+            CustomTextField(
+                value = email,
+                onValueChange = { email = it },
+                label = "이메일",
+                keyboardType = KeyboardType.Email
+            )
+            
+            CustomTextField(
+                value = password,
+                onValueChange = { password = it },
+                label = "비밀번호",
+                isPassword = true
+            )
+            
+            CustomTextField(
+                value = name,
+                onValueChange = { name = it },
+                label = "이름"
+            )
+            
+            CustomTextField(
+                value = nickname,
+                onValueChange = { nickname = it },
+                label = "닉네임"
+            )
+            
+            // 년도 드롭다운
+            ExposedDropdownMenuBox(
+                expanded = expandedYear,
+                onExpandedChange = { expandedYear = !expandedYear },
+                modifier = Modifier.fillMaxWidth().padding(bottom = 16.dp)
+            ) {
+                OutlinedTextField(
+                    value = selectedYear,
+                    onValueChange = { },
+                    readOnly = true,
+                    label = { Text("출생 년도", color = Color(0xFF9E9E9E)) },
+                    trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expandedYear) },
+                    modifier = Modifier.menuAnchor().fillMaxWidth(),
+                    shape = RoundedCornerShape(12.dp),
+                    colors = OutlinedTextFieldDefaults.colors(
+                        focusedTextColor = Color.White,
+                        unfocusedTextColor = Color.White,
+                        focusedBorderColor = Color(0xFF007AFF),
+                        unfocusedBorderColor = Color(0xFF424242),
+                        focusedContainerColor = Color.Transparent,
+                        unfocusedContainerColor = Color.Transparent
+                    ),
+                    singleLine = true
+                )
+                ExposedDropdownMenu(
+                    expanded = expandedYear,
+                    onDismissRequest = { expandedYear = false },
+                    modifier = Modifier.background(Color(0xFF2A2A2A))
+                ) {
+                    years.forEach { year ->
+                        DropdownMenuItem(
+                            text = { Text(text = year, color = Color.White) },
+                            onClick = {
+                                selectedYear = year
+                                expandedYear = false
+                            }
+                        )
+                    }
+                }
+            }
+            
+            // 성별 선택 (Radio Buttons)
+            Column(
+                modifier = Modifier.fillMaxWidth().padding(bottom = 32.dp),
+                horizontalAlignment = Alignment.Start
+            ) {
+                Text(
+                    text = "성별",
+                    fontSize = 14.sp,
+                    color = Color(0xFF9E9E9E),
+                    modifier = Modifier.padding(bottom = 8.dp)
+                )
+                Row(
+                    modifier = Modifier.fillMaxWidth().selectableGroup(),
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    genderOptions.forEach { text ->
+                        Row(
+                            Modifier
+                                .height(56.dp)
+                                .selectable(
+                                    selected = (text == selectedGender),
+                                    onClick = { selectedGender = text },
+                                    role = Role.RadioButton
+                                )
+                                .padding(horizontal = 8.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            RadioButton(
+                                selected = (text == selectedGender),
+                                onClick = null,
+                                colors = RadioButtonDefaults.colors(
+                                    selectedColor = Color(0xFF007AFF),
+                                    unselectedColor = Color(0xFF757575)
+                                )
+                            )
+                            Text(
+                                text = text,
+                                style = MaterialTheme.typography.bodyLarge,
+                                modifier = Modifier.padding(start = 8.dp),
+                                color = Color.White
+                            )
+                        }
+                    }
+                }
+            }
+            
+            AnimatedButtonLogin(
+                onClick = onNavigateToHome,
+                text = "가입 완료",
+                backgroundColor = Color(0xFF007AFF)
+            )
+            
+            Spacer(modifier = Modifier.height(16.dp))
+            
+            TextButton(onClick = onNavigateBack) {
+                Text(
+                    text = "이미 계정이 있으신가요? 로그인",
+                    color = Color(0xFF007AFF),
+                    fontSize = 14.sp
+                )
+            }
+            
+            Spacer(modifier = Modifier.height(48.dp))
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CustomTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    label: String,
+    isPassword: Boolean = false,
+    keyboardType: KeyboardType = KeyboardType.Text
+) {
+    OutlinedTextField(
+        value = value,
+        onValueChange = onValueChange,
+        label = { Text(label, color = Color(0xFF9E9E9E)) },
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(bottom = 16.dp),
+        shape = RoundedCornerShape(12.dp),
+        visualTransformation = if (isPassword) PasswordVisualTransformation() else androidx.compose.ui.text.input.VisualTransformation.None,
+        colors = OutlinedTextFieldDefaults.colors(
+            focusedTextColor = Color.White,
+            unfocusedTextColor = Color.White,
+            focusedBorderColor = Color(0xFF007AFF),
+            unfocusedBorderColor = Color(0xFF424242),
+            focusedContainerColor = Color.Transparent,
+            unfocusedContainerColor = Color.Transparent
+        ),
+        keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
+        singleLine = true
+    )
+}

--- a/app/src/main/java/ac/sbmax002/eye_on/ui/login/SignUpScreen.kt
+++ b/app/src/main/java/ac/sbmax002/eye_on/ui/login/SignUpScreen.kt
@@ -19,6 +19,11 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import ac.sbmax002.eye_on.network.NetworkConfig
+import ac.sbmax002.eye_on.network.SignupRequest
+import kotlinx.coroutines.launch
+import android.widget.Toast
+import androidx.compose.ui.platform.LocalContext
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -26,10 +31,12 @@ fun SignUpScreen(
     onNavigateToHome: () -> Unit,
     onNavigateBack: () -> Unit
 ) {
+    val context = LocalContext.current
     var email by remember { mutableStateOf("") }
     var password by remember { mutableStateOf("") }
     var name by remember { mutableStateOf("") }
     var nickname by remember { mutableStateOf("") }
+    val scope = rememberCoroutineScope()
     
     // 나이(년도) 드롭다운 상태
     var expandedYear by remember { mutableStateOf(false) }
@@ -179,7 +186,40 @@ fun SignUpScreen(
             }
             
             AnimatedButtonLogin(
-                onClick = onNavigateToHome,
+                onClick = {
+                    if (email.isNotBlank() && password.isNotBlank() && name.isNotBlank()) {
+                        scope.launch {
+                            try {
+                                val currentYear = java.util.Calendar.getInstance().get(java.util.Calendar.YEAR)
+                                val ageValue = if (selectedYear.isNotEmpty()) currentYear - selectedYear.toInt() + 1 else 20
+                                val response = NetworkConfig.authApiService.signUp(
+                                    SignupRequest(
+                                        email = email,
+                                        password = password,
+                                        organizationCode = "", // 서버 규격 호환
+                                        name = name,
+                                        nickname = nickname,
+                                        age = ageValue,
+                                        gender = if (selectedGender == "남") "MALE" else "FEMALE"
+                                    )
+                                )
+                                if (response.isSuccessful) {
+                                    Toast.makeText(context, "회원가입 성공!", Toast.LENGTH_SHORT).show()
+                                    onNavigateToHome()
+                                } else {
+                                    val msg = when(response.code()) {
+                                        409 -> "이미 사용 중인 이메일입니다."
+                                        400 -> "입력 양식을 확인해주세요."
+                                        else -> "회원가입 실패: ${response.code()}"
+                                    }
+                                    Toast.makeText(context, msg, Toast.LENGTH_SHORT).show()
+                                }
+                            } catch (e: Exception) {
+                                Toast.makeText(context, "네트워크 오류가 발생했습니다.", Toast.LENGTH_SHORT).show()
+                            }
+                        }
+                    }
+                },
                 text = "가입 완료",
                 backgroundColor = Color(0xFF007AFF)
             )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,8 +24,11 @@ mediapipe = "0.10.26.1"
 hilt = "2.51.1"
 datastore = "1.1.1"
 splashscreen = "1.0.1"
+retrofit = "2.11.0"
 
 [libraries]
+retrofit-core = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
+retrofit-gson = { group = "com.squareup.retrofit2", name = "converter-gson", version.ref = "retrofit" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-core-splashscreen = { group = "androidx.core", name = "core-splashscreen", version.ref = "splashscreen" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }


### PR DESCRIPTION
## 📝 개요
- localhost8080을 기준으로 회원가입&로그인 기능 구현

## 🔧 주요 작업(변경) 사항
  1. 시스템 설정 및 라이브러리 추가
   * AndroidManifest.xml: 로컬 서버(http://localhost:8080)와의 통신을 허용하기 위해 android:usesCleartextTraffic="true" 설정 추가
   *의존성 추가: 네트워크 통신 및 데이터 변환을 위해 Retrofit과 Gson 라이브러리를 설치

  2. 네트워크 레이어 구현 (신규 파일 3개)
   * NetworkConfig.kt: 공통 헤더(Accept, Content-Type) 설정 및 Retrofit 인스턴스를 생성
   * AuthApiService.kt: 서버의 인증 API 엔드포인트(로그인, 회원가입, 토큰 갱신, 로그아웃)를 정의
   * AuthDto.kt: Swagger 문서 스펙에 맞춰 서버와 주고받을 데이터 모델(Request/Response)을 생성
       * 앱 UI에서는 쓰지 않더라도 서버 호환성을 위해 organizationCode 필드를 DTO에 포함

  3. 기능 연동 및 UI 최적화
   * 로그인 (LoginScreen.kt):
       * 로그인 버튼 클릭 시 실제 API를 호출하도록 로직을 연동
       * 실패 시 사용자에게 알림을 주기 위해 Toast 메시지를 추가
   * 회원가입 (SignUpScreen.kt):

## 🎥 스크린샷/데모 (선택)
<이미지 또는 gif>

## 🔗 이슈 연결
- EYE-87

## ✅ 체크리스트
- [ ] merge branch 가 dev인가?
- [ ] 제목이 "[TYPE] [EYE-XX] 작업 개요"형태인가
- [ ] 테스트 했는가?
- [ ] 의존성이 있는 코드를 빠뜨리진 않았는가?
- [ ] 문서화 했는가?